### PR TITLE
Add support for displaying search terms in timer list

### DIFF
--- a/HISTORY
+++ b/HISTORY
@@ -1,3 +1,7 @@
+2025-07-28: 3.6.14
+- Enhanced the timer list display by adding a new column for search patterns.
+   Supports EPGSearch 'searchtimer' and TVScraper 'reason' fields
+
 2023-07-07:
 - Improvement: catch error during "delete record"
 - Adjust: suppress debug log output for "list record"
@@ -45,11 +49,11 @@
 - Adjust: renamed DESTDIR environment variable to PREFIX
 
 2014-08-05: 3.6.10
-- Improved: Optimized images to reduze their size. (Submitted by Ville Skyttä)
+- Improved: Optimized images to reduze their size. (Submitted by Ville Skyttï¿½)
 - Improved: Sort recordings secondarily by date when sorting by name. Makes the ordering stabler for multiple recordings with the same name. (Submitted by Olli Lammi)
 - Added: streaming of recordings folders (Submitted by Daniel Matzke).
-- Added: Hungarian translation (Submitted by István Füley).
-- Fixed LSTR when executing recording commands on VDR >= 1.7.21 (Submitted by David Rütti)
+- Added: Hungarian translation (Submitted by Istvï¿½n Fï¿½ley).
+- Fixed LSTR when executing recording commands on VDR >= 1.7.21 (Submitted by David Rï¿½tti)
 - Updated: Italian translation (thanks to Diego Pierotto).
 - Updated: Finnish translation.
 
@@ -94,7 +98,7 @@
 - Updated: Spanish translation (Submitted by Manuel Gomez).
 - Improved: Default mail settings.
 - Fixed: Check if "GUI_POPUP_WIDTH" and "GUI_POPUP_HEIGHT" are numeric and set them to the defaults if they are not (Reported by Jan).
-- Added: Support VDR 1.7.12+ commands.conf and reccmds.conf (means: skip lines ending in "{" and lines with only "}" in them). 
+- Added: Support VDR 1.7.12+ commands.conf and reccmds.conf (means: skip lines ending in "{" and lines with only "}" in them).
 - Added: check file and directory permissions on startup abort on error.
 - Changed: Default directory for PID file to /var/run/vdradmin.
 - Changed: Default directory for log file to /var/log/vdradmin.
@@ -149,8 +153,8 @@
 - Updated: Finnish translation
 
 2008-12-13: 3.6.3
-- Updated: Spanish translation (Submitted by Rüdiger Jung).
-- Changed: Process name to "vdradmind" (Based on patch submitted by Ville Skyttä).
+- Updated: Spanish translation (Submitted by Rï¿½diger Jung).
+- Changed: Process name to "vdradmind" (Based on patch submitted by Ville Skyttï¿½).
 - Updated: Italian translation (Submitted by Diego Pierotto).
 - Changed executable's name from "vdradmind.pl" to "vdradmind".
 - Updated: Dutch translation (Submitted by Roel Koelewijn).
@@ -170,7 +174,7 @@
 - Added: ST_STREAMDEV_HOST config option to set the name/ip to be used for streaming.
 - Fixed: m3u files for Xine (Reported by Robert C. Helling).
 - Updated: Italian translation (Submitted by Diego Pierotto).
-- Updated: Spanish translation (Submitted by Rüdiger Jung).
+- Updated: Spanish translation (Submitted by Rï¿½diger Jung).
 - Updated: Finnish translation (Submitted by Rolf Ahrenberg).
 - Changed: include UTF8 locales by default.
 - Introduced new config options "GUI_POPUP_WIDTH" and "GUI_POPUP_HEIGHT" for setting the prog_detail's window size (Requested by Viking @vdr-portal.de).
@@ -195,13 +199,13 @@
 - Changed: prog_timeline uses global channels array instead of copying it locally.
 - Fixed: Bug in prog_timeline introduced in 3.6.0beta (Reported by several users).
 - Updated: Italian translation (Submitted by Diego Pierotto)
-- Updated: Spanish translation (Submitted by Rüdiger Jung).
+- Updated: Spanish translation (Submitted by Rï¿½diger Jung).
 - Fixed: Channel range in epgsearch_new didn't work since 3.6.0beta (Reported by mblaster4711 @vdr-portal.de).
 
 2007-08-27: 3.6.0rc
 - Updated: French translation (Submitted by Trois Six).
 - Updated: Dutch translation (Submitted by Roel Koelewijn).
-- Updated: Finnish translation (Submitted by Ville Skyttä & Rolf Ahrenberg).
+- Updated: Finnish translation (Submitted by Ville Skyttï¿½ & Rolf Ahrenberg).
 - Reworked: configuration part: selected channels work again and settings are only applied if "save" or "apply" is pressed in config menu.
 - Fixed: initialisation of CHANNEL_WANTED_<area> config options.
 
@@ -229,7 +233,7 @@
 - Added: New "--pid" vdradmind.pl to set the used pidfile.
 - Added: extended information in m3u file used for livetv streaming (Submitted by Samuli Sorvakko).
 - Changed: IMDb search URL can be modified.
-- Added: Optional user defined external search (Based on suggestion by Axel Röhken).
+- Added: Optional user defined external search (Based on suggestion by Axel Rï¿½hken).
 - Fixed: Saving of wrong timer if repeating timers have no day set (= "-------").
 - Added: Record button to epgsearch result list if no timer is set.
 - Added: Support for epgsearch's timer checking.
@@ -385,7 +389,7 @@
 - Changed: request full "from" email address for sending emails instead of domain only (Requested by siryoda).
 - Changed: no red background for inactive timers in prog_timeline (Requested by Zimbo).
 - Changed: result of a search is ordered by the event's start time instead of channel id (Suggested by scorp).
-- Fixed: crashes when sending emails (Thanks to Ville Skyttä for hints and siryoda for testing).
+- Fixed: crashes when sending emails (Thanks to Ville Skyttï¿½ for hints and siryoda for testing).
 - Fixed: error page sets charset correct.
 - Added: russian translation (Thanks to Oleg Roitburd and Allrussian-forum translation team)
 - Fixed: lots of perl warnings.
@@ -410,7 +414,7 @@
 - Moved "help" menu into "about" menu.
 - Added VDR's "commands.conf" conntent to select box in navigation menu.
 - Changed defaults for "autotimer checking" in timers as they had been in v3.4.3.
-- New button on remote controls: Mute (Requested by Rüdiger Jung and Hardy Flor).
+- New button on remote controls: Mute (Requested by Rï¿½diger Jung and Hardy Flor).
 - Timeline in timer_list will show timers of current day even if a timer starts the day before (Reported by Hardy Flor).
 
 2006-03-08: 3.4.4beta
@@ -446,7 +450,7 @@
 - Hide "Record" button if prog_detail is opened from timer_list.
 - After clicking "Record" in prog_detail and leaving timer_new return to page where prog_detail has been opened (Reported by Ferdinand Grassmann).
 - Timers were re-programmed every CheckTimers() call if setup option "do not add summary to timers" is active (Reported by Ferdinand Grassmann).
-- Dropped sendEmail dependency. Now uses Net::SMTP modules (Patch by Ville Skyttä).
+- Dropped sendEmail dependency. Now uses Net::SMTP modules (Patch by Ville Skyttï¿½).
 - Don't show EPG images for other events (Fixed by Ferdinand Grassmann).
 - Changed GRAB so that it doesn't use temporary files for VDR >=1.3.38.
 - VPS for timers (Requested by reibuehl).
@@ -494,8 +498,8 @@
 - Channel select box in TV.
 - "Test" button in AutoTimer edit for showing results of current settings (Requested by Hardy Flor).
 - Link from channel name in prog_list2 and timer_list to prog_list.
-- Bring popups to the front (e.g. help, prog_detail...) (Based on a patch submitted by Ville Skyttä).
-- Reuse existing TV, RC and help windows (Based on a patch submitted by Ville Skyttä).
+- Bring popups to the front (e.g. help, prog_detail...) (Based on a patch submitted by Ville Skyttï¿½).
+- Reuse existing TV, RC and help windows (Based on a patch submitted by Ville Skyttï¿½).
 - Send vdradmin.m3u when streaming.
 - Tooltips in timer_list, prog_timeline and at_timer_list can be deactivated (Requested by Hardy Flor).
 - Fixed wrong HTML tags in rec_detail (Reported by foobar42).
@@ -512,18 +516,18 @@
 - Fixed some more HTMLtidy warnings.
 
 2005-09-23: 0.97-am3.4
-- Send valid "Expires" header (Submitted by Ville Skyttä).
-- Open failure of vdradmind.done reported wrong filename (Submitted by Ville Skyttä).
-- Deliver validated HTML (Reported by Ville Skyttä).
+- Send valid "Expires" header (Submitted by Ville Skyttï¿½).
+- Open failure of vdradmind.done reported wrong filename (Submitted by Ville Skyttï¿½).
+- Deliver validated HTML (Reported by Ville Skyttï¿½).
 - Display name of recordings/timers... that will be deleted (Requested by Richard Lithvall).
 - Channels list in AutoTimer only shows selected channels if selective channels are active for AT.
 - Added "chmod" for grabbed images of TV so that everyone can read/write the file (Submitted by Udo Richter).
 - Added "-d" argument to set the configuration folder (Submitted by Rene Bredlau).
 - Fixed handling for recording on February, 29th for VDR >=1.3.26 (Submitted by Rene Bredlau).
-- Alternativly use Locale::Messages if Locale::gettext not found (Submitted by Ville Skyttä).
-- Fixed "send command" error message (Submitted by Ville Skyttä).
+- Alternativly use Locale::Messages if Locale::gettext not found (Submitted by Ville Skyttï¿½).
+- Fixed "send command" error message (Submitted by Ville Skyttï¿½).
 - Display free disk size as float instead of integer (Submitted by Hardy Flor).
-- Step forward/backward a day in "Playing today" (Requested by Tüddelkopp)
+- Step forward/backward a day in "Playing today" (Requested by Tï¿½ddelkopp)
 - Enable/disable selective channels in "Playing today" (Requested by Reiner Buehl)
 - Added images in prog_detail; needs external tool that provides these images; must be configured first! (Requested by several people)
 - Fixed display of login page (Reported by DrSat)
@@ -585,13 +589,13 @@
 - Use configured Streamdev port for live streaming.
 - Added warning when using EPG_DIRECT.
 - Updated INSTALL file.
-- Renamed i18n Español to Spanish (Requested by Ruediger Jung).
+- Renamed i18n Espaï¿½ol to Spanish (Requested by Ruediger Jung).
 - Fixed ":" & "|" handling in timer's title and summary (Thanks to Der_Pit for pointing me to that).
 - Added "Select all" to timer/autotimer/recordings list.
 - Exchanged priority and lifetime textfields in config.html to match order used at other places (Requested by Ruediger Jung).
 - Added vdradmin-0.95-0.9pre5-email.diff (Author: blafasel) patch: send email on timers added by AutoTimer (needs sendEmail available here: http://caspian.dotconf.net/menu/Software/SendEmail/).
 - Fixed timer add/edit where date got set wrong in case it has been entered as "yyyy-mm-dd".
-- Fixed problems when using MOD_GZIP (Thanks Ville Skyttä).
+- Fixed problems when using MOD_GZIP (Thanks Ville Skyttï¿½).
 - Fixed Makefile once again (Thanks Zzam for pointing me to this).
 - Added patches submitted by stefan.h (Thanks!):
   -> New config option EPG_PRUNE. You can set a channel number up to which VDRAdmin will read EPG. Might reduce memory usage and read-in time. Set to "0" to read all channels.
@@ -602,12 +606,12 @@
 - Reworked updating of channels and EPG from VDR.
 - Fixed displaying of repeating timers.
 - Fixed Makefile to set "$SEARCH_FILES_IN_SYSTEM = 1" on install.
-- Added Spanish i18n (Submitted by Rüdiger Jung)
+- Added Spanish i18n (Submitted by Rï¿½diger Jung)
 - Updated French i18n (Submitted by "Trois Six",  "map" and "lobotomise")
 - Fixed some buttons to work with long translations.
 - Extracted text from templates and moved them to i18n.pl file and moved the i18n.pl files to new folders i18n/$language, resulting in a single template with two skins (bilder & copper). Makes translations and template modification a lot more easier.
 
-Included patches submitted by Ville Skyttä:
+Included patches submitted by Ville Skyttï¿½:
 - vdradmin-01-req-zlib.patch: Make Compress::Zlib really optional.
 - vdradmin-02-defaultconfig.patch: Use preset values from %CONFIG as defaults in --config.
 - vdradmin-03-errstr.patch: Fix error string output.
@@ -690,7 +694,7 @@ This is mainly the lastest vdradmin (v0.97) with different patches applied:
 - Included vdradmin-0.96-rename.diff which also needs an applied "vdr-aio21_svdrprename.patch" or enAIO-v2.2 patch (Author: slime).
 
 My own changes:
-- Included missing "Was läuft heute?" template (found at www.vdr-portal.de).
+- Included missing "Was lï¿½uft heute?" template (found at www.vdr-portal.de).
 - Fixed some rendering problems with "New Timer" and "New Autotimer" on KDE's Konqueror.
 - Beautified recordings listing (at least in my eyes ;-)
 - Added "Size" selectbox to TV template.

--- a/HISTORY
+++ b/HISTORY
@@ -49,11 +49,11 @@
 - Adjust: renamed DESTDIR environment variable to PREFIX
 
 2014-08-05: 3.6.10
-- Improved: Optimized images to reduze their size. (Submitted by Ville Skytt�)
+- Improved: Optimized images to reduze their size. (Submitted by Ville Skyttä)
 - Improved: Sort recordings secondarily by date when sorting by name. Makes the ordering stabler for multiple recordings with the same name. (Submitted by Olli Lammi)
 - Added: streaming of recordings folders (Submitted by Daniel Matzke).
-- Added: Hungarian translation (Submitted by Istv�n F�ley).
-- Fixed LSTR when executing recording commands on VDR >= 1.7.21 (Submitted by David R�tti)
+- Added: Hungarian translation (Submitted by István Füley).
+- Fixed LSTR when executing recording commands on VDR >= 1.7.21 (Submitted by David Rütti)
 - Updated: Italian translation (thanks to Diego Pierotto).
 - Updated: Finnish translation.
 
@@ -153,8 +153,8 @@
 - Updated: Finnish translation
 
 2008-12-13: 3.6.3
-- Updated: Spanish translation (Submitted by R�diger Jung).
-- Changed: Process name to "vdradmind" (Based on patch submitted by Ville Skytt�).
+- Updated: Spanish translation (Submitted by Rüdiger Jung).
+- Changed: Process name to "vdradmind" (Based on patch submitted by Ville Skyttä).
 - Updated: Italian translation (Submitted by Diego Pierotto).
 - Changed executable's name from "vdradmind.pl" to "vdradmind".
 - Updated: Dutch translation (Submitted by Roel Koelewijn).
@@ -174,7 +174,7 @@
 - Added: ST_STREAMDEV_HOST config option to set the name/ip to be used for streaming.
 - Fixed: m3u files for Xine (Reported by Robert C. Helling).
 - Updated: Italian translation (Submitted by Diego Pierotto).
-- Updated: Spanish translation (Submitted by R�diger Jung).
+- Updated: Spanish translation (Submitted by Rüdiger Jung).
 - Updated: Finnish translation (Submitted by Rolf Ahrenberg).
 - Changed: include UTF8 locales by default.
 - Introduced new config options "GUI_POPUP_WIDTH" and "GUI_POPUP_HEIGHT" for setting the prog_detail's window size (Requested by Viking @vdr-portal.de).
@@ -199,13 +199,13 @@
 - Changed: prog_timeline uses global channels array instead of copying it locally.
 - Fixed: Bug in prog_timeline introduced in 3.6.0beta (Reported by several users).
 - Updated: Italian translation (Submitted by Diego Pierotto)
-- Updated: Spanish translation (Submitted by R�diger Jung).
+- Updated: Spanish translation (Submitted by Rüdiger Jung).
 - Fixed: Channel range in epgsearch_new didn't work since 3.6.0beta (Reported by mblaster4711 @vdr-portal.de).
 
 2007-08-27: 3.6.0rc
 - Updated: French translation (Submitted by Trois Six).
 - Updated: Dutch translation (Submitted by Roel Koelewijn).
-- Updated: Finnish translation (Submitted by Ville Skytt� & Rolf Ahrenberg).
+- Updated: Finnish translation (Submitted by Ville Skyttä & Rolf Ahrenberg).
 - Reworked: configuration part: selected channels work again and settings are only applied if "save" or "apply" is pressed in config menu.
 - Fixed: initialisation of CHANNEL_WANTED_<area> config options.
 
@@ -233,7 +233,7 @@
 - Added: New "--pid" vdradmind.pl to set the used pidfile.
 - Added: extended information in m3u file used for livetv streaming (Submitted by Samuli Sorvakko).
 - Changed: IMDb search URL can be modified.
-- Added: Optional user defined external search (Based on suggestion by Axel R�hken).
+- Added: Optional user defined external search (Based on suggestion by Axel Röhken).
 - Fixed: Saving of wrong timer if repeating timers have no day set (= "-------").
 - Added: Record button to epgsearch result list if no timer is set.
 - Added: Support for epgsearch's timer checking.
@@ -389,7 +389,7 @@
 - Changed: request full "from" email address for sending emails instead of domain only (Requested by siryoda).
 - Changed: no red background for inactive timers in prog_timeline (Requested by Zimbo).
 - Changed: result of a search is ordered by the event's start time instead of channel id (Suggested by scorp).
-- Fixed: crashes when sending emails (Thanks to Ville Skytt� for hints and siryoda for testing).
+- Fixed: crashes when sending emails (Thanks to Ville Skyttä for hints and siryoda for testing).
 - Fixed: error page sets charset correct.
 - Added: russian translation (Thanks to Oleg Roitburd and Allrussian-forum translation team)
 - Fixed: lots of perl warnings.
@@ -414,7 +414,7 @@
 - Moved "help" menu into "about" menu.
 - Added VDR's "commands.conf" conntent to select box in navigation menu.
 - Changed defaults for "autotimer checking" in timers as they had been in v3.4.3.
-- New button on remote controls: Mute (Requested by R�diger Jung and Hardy Flor).
+- New button on remote controls: Mute (Requested by Rüdiger Jung and Hardy Flor).
 - Timeline in timer_list will show timers of current day even if a timer starts the day before (Reported by Hardy Flor).
 
 2006-03-08: 3.4.4beta
@@ -450,7 +450,7 @@
 - Hide "Record" button if prog_detail is opened from timer_list.
 - After clicking "Record" in prog_detail and leaving timer_new return to page where prog_detail has been opened (Reported by Ferdinand Grassmann).
 - Timers were re-programmed every CheckTimers() call if setup option "do not add summary to timers" is active (Reported by Ferdinand Grassmann).
-- Dropped sendEmail dependency. Now uses Net::SMTP modules (Patch by Ville Skytt�).
+- Dropped sendEmail dependency. Now uses Net::SMTP modules (Patch by Ville Skyttä).
 - Don't show EPG images for other events (Fixed by Ferdinand Grassmann).
 - Changed GRAB so that it doesn't use temporary files for VDR >=1.3.38.
 - VPS for timers (Requested by reibuehl).
@@ -498,8 +498,8 @@
 - Channel select box in TV.
 - "Test" button in AutoTimer edit for showing results of current settings (Requested by Hardy Flor).
 - Link from channel name in prog_list2 and timer_list to prog_list.
-- Bring popups to the front (e.g. help, prog_detail...) (Based on a patch submitted by Ville Skytt�).
-- Reuse existing TV, RC and help windows (Based on a patch submitted by Ville Skytt�).
+- Bring popups to the front (e.g. help, prog_detail...) (Based on a patch submitted by Ville Skyttä).
+- Reuse existing TV, RC and help windows (Based on a patch submitted by Ville Skyttä).
 - Send vdradmin.m3u when streaming.
 - Tooltips in timer_list, prog_timeline and at_timer_list can be deactivated (Requested by Hardy Flor).
 - Fixed wrong HTML tags in rec_detail (Reported by foobar42).
@@ -516,18 +516,18 @@
 - Fixed some more HTMLtidy warnings.
 
 2005-09-23: 0.97-am3.4
-- Send valid "Expires" header (Submitted by Ville Skytt�).
-- Open failure of vdradmind.done reported wrong filename (Submitted by Ville Skytt�).
-- Deliver validated HTML (Reported by Ville Skytt�).
+- Send valid "Expires" header (Submitted by Ville Skyttä).
+- Open failure of vdradmind.done reported wrong filename (Submitted by Ville Skyttä).
+- Deliver validated HTML (Reported by Ville Skyttä).
 - Display name of recordings/timers... that will be deleted (Requested by Richard Lithvall).
 - Channels list in AutoTimer only shows selected channels if selective channels are active for AT.
 - Added "chmod" for grabbed images of TV so that everyone can read/write the file (Submitted by Udo Richter).
 - Added "-d" argument to set the configuration folder (Submitted by Rene Bredlau).
 - Fixed handling for recording on February, 29th for VDR >=1.3.26 (Submitted by Rene Bredlau).
-- Alternativly use Locale::Messages if Locale::gettext not found (Submitted by Ville Skytt�).
-- Fixed "send command" error message (Submitted by Ville Skytt�).
+- Alternativly use Locale::Messages if Locale::gettext not found (Submitted by Ville Skyttä).
+- Fixed "send command" error message (Submitted by Ville Skyttä).
 - Display free disk size as float instead of integer (Submitted by Hardy Flor).
-- Step forward/backward a day in "Playing today" (Requested by T�ddelkopp)
+- Step forward/backward a day in "Playing today" (Requested by Tüddelkopp)
 - Enable/disable selective channels in "Playing today" (Requested by Reiner Buehl)
 - Added images in prog_detail; needs external tool that provides these images; must be configured first! (Requested by several people)
 - Fixed display of login page (Reported by DrSat)
@@ -589,13 +589,13 @@
 - Use configured Streamdev port for live streaming.
 - Added warning when using EPG_DIRECT.
 - Updated INSTALL file.
-- Renamed i18n Espa�ol to Spanish (Requested by Ruediger Jung).
+- Renamed i18n Español to Spanish (Requested by Ruediger Jung).
 - Fixed ":" & "|" handling in timer's title and summary (Thanks to Der_Pit for pointing me to that).
 - Added "Select all" to timer/autotimer/recordings list.
 - Exchanged priority and lifetime textfields in config.html to match order used at other places (Requested by Ruediger Jung).
 - Added vdradmin-0.95-0.9pre5-email.diff (Author: blafasel) patch: send email on timers added by AutoTimer (needs sendEmail available here: http://caspian.dotconf.net/menu/Software/SendEmail/).
 - Fixed timer add/edit where date got set wrong in case it has been entered as "yyyy-mm-dd".
-- Fixed problems when using MOD_GZIP (Thanks Ville Skytt�).
+- Fixed problems when using MOD_GZIP (Thanks Ville Skyttä).
 - Fixed Makefile once again (Thanks Zzam for pointing me to this).
 - Added patches submitted by stefan.h (Thanks!):
   -> New config option EPG_PRUNE. You can set a channel number up to which VDRAdmin will read EPG. Might reduce memory usage and read-in time. Set to "0" to read all channels.
@@ -606,12 +606,12 @@
 - Reworked updating of channels and EPG from VDR.
 - Fixed displaying of repeating timers.
 - Fixed Makefile to set "$SEARCH_FILES_IN_SYSTEM = 1" on install.
-- Added Spanish i18n (Submitted by R�diger Jung)
+- Added Spanish i18n (Submitted by Rüdiger Jung)
 - Updated French i18n (Submitted by "Trois Six",  "map" and "lobotomise")
 - Fixed some buttons to work with long translations.
 - Extracted text from templates and moved them to i18n.pl file and moved the i18n.pl files to new folders i18n/$language, resulting in a single template with two skins (bilder & copper). Makes translations and template modification a lot more easier.
 
-Included patches submitted by Ville Skytt�:
+Included patches submitted by Ville Skyttä:
 - vdradmin-01-req-zlib.patch: Make Compress::Zlib really optional.
 - vdradmin-02-defaultconfig.patch: Use preset values from %CONFIG as defaults in --config.
 - vdradmin-03-errstr.patch: Fix error string output.
@@ -694,7 +694,7 @@ This is mainly the lastest vdradmin (v0.97) with different patches applied:
 - Included vdradmin-0.96-rename.diff which also needs an applied "vdr-aio21_svdrprename.patch" or enAIO-v2.2 patch (Author: slime).
 
 My own changes:
-- Included missing "Was l�uft heute?" template (found at www.vdr-portal.de).
+- Included missing "Was läuft heute?" template (found at www.vdr-portal.de).
 - Fixed some rendering problems with "New Timer" and "New Autotimer" on KDE's Konqueror.
 - Beautified recordings listing (at least in my eyes ;-)
 - Added "Size" selectbox to TV template.

--- a/template/default/epgsearch_list.html
+++ b/template/default/epgsearch_list.html
@@ -1,77 +1,92 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<!DOCTYPE html
+	PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html id="scroller">
 <?% USE JavaScript, HTML %?>
+
 <head>
-	<meta http-equiv="content-type" content="text/html;charset=<?% charset %?>"/>
-	<title>VDRAdmin-AM - <?% gettext('EPG search') %?></title>
-	<link href="style.css" rel="stylesheet" media="screen" type="text/css"/>
+	<meta http-equiv="content-type" content="text/html;charset=<?% charset %?>" />
+	<title>VDRAdmin-AM -
+		<?% gettext('EPG search') %?>
+	</title>
+	<link href="style.css" rel="stylesheet" media="screen" type="text/css" />
 	<?% IF usercss %?>
-		<link href="user.css" rel="stylesheet" media="screen" type="text/css"/>
+	<link href="user.css" rel="stylesheet" media="screen" type="text/css" />
 	<?% END %?>
 	<script type="text/javascript" language="JavaScript1.2" src="library.js"></script>
 	<?% IF config.AT_TOOLTIP %?>
-		<script type="text/javascript" language="JavaScript1.2" src="infobox.js"></script>
+	<script type="text/javascript" language="JavaScript1.2" src="infobox.js"></script>
 	<?% END %?>
 </head>
 
 <body id="epgsearch_list">
-<?% UNLESS did_search %?>
+	<?% UNLESS did_search %?>
 	<form action="<?% url %?>" method="get" name="FormName0">
 		<table width="100%" border="0" cellspacing="0" cellpadding="0" id="heading">
 			<tr>
 				<td class="col_title">
-					<h1><?% gettext('EPG Search') %?></h1>
+					<h1>
+						<?% gettext('EPG Search') %?>
+					</h1>
 				</td>
 				<td class="col_other">
 					<?% IF templates.size() > 0 %?>
-						<?% gettext('Use template') %?>
-						<select name="template">
-							<?% FOREACH templ = templates %?>
-								<option value="<?% templ.id %?>" <?% IF templ.sel %?>selected="selected"<?% END %?>><?% templ.pattern %?></option>
-							<?% END %?>
-						</select>
+					<?% gettext('Use template') %?>
+					<select name="template">
+						<?% FOREACH templ = templates %?>
+						<option value="<?% templ.id %?>" <?% IF templ.sel %?>selected="selected"
+							<?% END %?>>
+							<?% templ.pattern %?>
+						</option>
+						<?% END %?>
+					</select>
 					<?% END %?>
 					<input type="submit" class="submit" name="new_search" value="<?% gettext('New Search') %?>" />
 					<input type="submit" class="submit" name="edit_template" value="<?% gettext('Edit Template') %?>" />
 					<input type="hidden" name="aktion" value="epgsearch_edit" />
 				</td>
 				<td class="col_help">
-<?% IF config_url %?>
-          <a href="<?% config_url %?>"><img src="bilder/configure.png" border="0" alt="settings" title="<?% gettext('Settings') %?>"/></a>
-<?% END %?>
-<?% IF help_url %?>
-					<a href="javascript:open_help('<?% help_url %?>');"><img src="bilder/help.png" border="0" alt="help" title="<?% gettext('Help') %?>"/></a>
-<?% END %?>
+					<?% IF config_url %?>
+					<a href="<?% config_url %?>"><img src="bilder/configure.png" border="0" alt="settings"
+							title="<?% gettext('Settings') %?>" /></a>
+					<?% END %?>
+					<?% IF help_url %?>
+					<a href="javascript:open_help('<?% help_url %?>');"><img src="bilder/help.png" border="0" alt="help"
+							title="<?% gettext('Help') %?>" /></a>
+					<?% END %?>
 				</td>
 			</tr>
 		</table>
 	</form>
 
-<?% IF error_msg %?>
-		<div class="error"><?% error_msg %?></div>
-<?% END %?>
+	<?% IF error_msg %?>
+	<div class="error">
+		<?% error_msg %?>
+	</div>
+	<?% END %?>
 
 	<form action="<?% url %?>" method="get" name="FormName">
 		<table width="100%" border="0" cellspacing="0" cellpadding="0" id="content" class="list hilight">
 			<tr class="heading">
 				<td class="col_active <?% IF sortbyactive %?>selected<?% END %?>">
 					<h2>
-						<a href="<?% sortbyactiveurl %?>"><?% gettext('Active') %?>
+						<a href="<?% sortbyactiveurl %?>">
+							<?% gettext('Active') %?>
 							<?% IF sortbyactive %?>
-								<img src="bilder/sortiert_<?% desc %?>.gif" alt="" width="9" height="11" border="0"/>
+							<img src="bilder/sortiert_<?% desc %?>.gif" alt="" width="9" height="11" border="0" />
 							<?% ELSE %?>
-								<img src="bilder/spacer.gif" alt="" width="9" height="11" border="0"/>
+							<img src="bilder/spacer.gif" alt="" width="9" height="11" border="0" />
 							<?% END %?>
 						</a>
 					</h2>
 				</td>
 				<td class="col_action <?% IF sortbyaction %?>selected<?% END %?>">
 					<h2>
-						<a href="<?% sortbyactionurl %?>"><?% gettext('Action') %?>
+						<a href="<?% sortbyactionurl %?>">
+							<?% gettext('Action') %?>
 							<?% IF sortbyaction %?>
-								<img src="bilder/sortiert_<?% desc %?>.gif" alt="" width="9" height="11" border="0"/>
+							<img src="bilder/sortiert_<?% desc %?>.gif" alt="" width="9" height="11" border="0" />
 							<?% ELSE %?>
-								<img src="bilder/spacer.gif" alt="" width="9" height="11" border="0"/>
+							<img src="bilder/spacer.gif" alt="" width="9" height="11" border="0" />
 							<?% END %?>
 						</a>
 					</h2>
@@ -120,78 +135,103 @@
 				</td>
 				<td class="col_name <?% IF sortbypattern %?>selected<?% END %?>">
 					<h2>
-						<a href="<?% sortbypatternurl %?>"><?% gettext('Search pattern') %?>
+						<a href="<?% sortbypatternurl %?>">
+							<?% gettext('Search pattern') %?>
 							<?% IF sortbypattern %?>
-								<img src="bilder/sortiert_<?% desc %?>.gif" alt="" width="9" height="11" border="0"/>
+							<img src="bilder/sortiert_<?% desc %?>.gif" alt="" width="9" height="11" border="0" />
 							<?% ELSE %?>
-								<img src="bilder/spacer.gif" alt="" width="9" height="11" border="0"/>
+							<img src="bilder/spacer.gif" alt="" width="9" height="11" border="0" />
 							<?% END %?>
 						</a>
 					</h2>
 				</td>
 				<td class="col_buttons"></td>
-				<td class="col_checkbox"><input type="checkbox" name="SELALL" value="SELALL" onclick="AllMessages(this.form);" title="<?% gettext('Select all/none') %?>"/></td>
+				<td class="col_checkbox"><input type="checkbox" name="SELALL" value="SELALL"
+						onclick="AllMessages(this.form);" title="<?% gettext('Select all/none') %?>" /></td>
 			</tr>
 
-<?% FOREACH searches %?>
+			<?% FOREACH searches %?>
 			<tr class="<?% IF loop.count % 2 == 0 %?>row_even<?% ELSE %?>row_odd<?% END %?>">
 				<td class="col_active <?% IF sortbyactive %?>selected<?% END %?>">
 					<div>
 						<?% IF has_action %?>
-							<a href="<?% toggleurl %?>"><img src="bilder/poempl_gruen.png" alt="" align="middle" border="0"/> <?% gettext('Yes') %?></a>
+						<a href="<?% toggleurl %?>"><img src="bilder/poempl_gruen.png" alt="" align="middle"
+								border="0" />
+							<?% gettext('Yes') %?>
+						</a>
 						<?% ELSE %?>
-							<a href="<?% toggleurl %?>"><img src="bilder/poempl_grau.png" alt="" align="middle" border="0"/> <?% gettext('No') %?></a>
+						<a href="<?% toggleurl %?>"><img src="bilder/poempl_grau.png" alt="" align="middle"
+								border="0" />
+							<?% gettext('No') %?>
+						</a>
 						<?% END %?>
 					</div>
 				</td>
 				<td class="col_active <?% IF sortbyactive %?>selected<?% END %?>">
-					<div><?% action_text %?></div>
+					<div>
+						<?% action_text %?>
+					</div>
 				</td>
 				<td class="col_channel <?% IF sortbychannel %?>selected<?% END %?>">
 					<div>
 						<?% SWITCH use_channel %?>
 						<?% CASE 1 %?>
-							<?% channel_from_name %?><?% IF channel_from_name != channel_to_name %?> - <?% channel_to_name %?><?% END %?>
+						<?% channel_from_name %?>
+						<?% IF channel_from_name != channel_to_name %?> -
+						<?% channel_to_name %?>
+						<?% END %?>
 						<?% CASE 2 %?>
-							<?% channels %?>
+						<?% channels %?>
 						<?% CASE %?>
-							-
+						-
 						<?% END %?>
 					</div>
 				</td>
 				<td class="col_start <?% IF sortbystart %?>selected<?% END %?>">
 					<div>
-						<?% IF time_start %?><?% time_start %?><?% ELSE %?>--:--<?% END %?>
+						<?% IF time_start %?>
+						<?% time_start %?>
+						<?% ELSE %?>--:--
+						<?% END %?>
 					</div>
 				</td>
 				<td class="col_stop <?% IF sortbystop %?>selected<?% END %?>">
 					<div>
-						<?% IF time_stop %?><?% time_stop %?><?% ELSE %?>--:--<?% END %?>
+						<?% IF time_stop %?>
+						<?% time_stop %?>
+						<?% ELSE %?>--:--
+						<?% END %?>
 					</div>
 				</td>
 				<td class="col_name <?% IF sortbypattern %?>selected<?% END %?>">
 					<div>
-						<a href="<?% modurl %?>" title="<?% gettext('Edit') %?>"><?% pattern | html %?></a>
+						<a href="<?% modurl %?>" title="<?% gettext('Edit') %?>">
+							<?% pattern | html %?>
+						</a>
 					</div>
 				</td>
 				<td class="col_buttons">
 					<span class="action find">
-						<a href="<?% findurl %?>"><img src="bilder/find.png" alt="find" border="0" title="<?% gettext('Find') %?>"/></a>
+						<a href="<?% findurl %?>"><img src="bilder/find.png" alt="find" border="0"
+								title="<?% gettext('Find') %?>" /></a>
 					</span>
 					<span class="action edit">
-						<a href="<?% modurl %?>"><img src="bilder/edit.png" alt="edit" border="0" title="<?% gettext('Edit') %?>"/></a>
+						<a href="<?% modurl %?>"><img src="bilder/edit.png" alt="edit" border="0"
+								title="<?% gettext('Edit') %?>" /></a>
 					</span>
 					<span class="action delete">
-						<a href="javascript:del('<?% gettext('Delete timer?') %?>\n\n&quot;<?% pattern | js %?>&quot;', '<?% delurl %?>');"><img src="bilder/delete.png" alt="delete" border="0" title="<?% gettext('Delete') %?>"/></a>
+						<a
+							href="javascript:del('<?% gettext('Delete timer?') %?>\n\n&quot;<?% pattern | js %?>&quot;', '<?% delurl %?>');"><img
+								src="bilder/delete.png" alt="delete" border="0" title="<?% gettext('Delete') %?>" /></a>
 					</span>
 				</td>
 				<td class="col_checkbox">
 					<div>
-						<input type="checkbox" name="xxxx_<?% id %?>"/>
+						<input type="checkbox" name="xxxx_<?% id %?>" />
 					</div>
 				</td>
 			</tr>
-<?% END %?>
+			<?% END %?>
 		</table>
 
 		<table width="100%" border="0" cellspacing="0" cellpadding="0" id="buttons">
@@ -201,30 +241,35 @@
 					<input type="submit" class="submit" name="upds" value="<?% gettext('Force Update') %?>" />
 				</td>
 				<td align="right">
-					<input type="submit" class="submit" name="delete" value="<?% gettext('Delete Selected Searches') %?>" onclick="return mdel(this, '<?% gettext('Delete all selected searches?') %?>');" />
-					<input type="submit" class="submit" name="execute" value="<?% gettext('Execute Selected Searches') %?>" />
+					<input type="submit" class="submit" name="delete"
+						value="<?% gettext('Delete Selected Searches') %?>"
+						onclick="return mdel(this, '<?% gettext('Delete all selected searches?') %?>');" />
+					<input type="submit" class="submit" name="execute"
+						value="<?% gettext('Execute Selected Searches') %?>" />
 				</td>
 			</tr>
 		</table>
-		<input type="hidden" name="aktion" value="epgsearch_aktion"/>
+		<input type="hidden" name="aktion" value="epgsearch_aktion" />
 
 	</form>
-<?% END %?>
+	<?% END %?>
 
-<?% IF did_search %?>
+	<?% IF did_search %?>
 	<form action="<?% url %?>" method="get" name="FormName0">
 		<table width="100%" border="0" cellspacing="0" cellpadding="0" id="heading">
 			<tr>
 				<td class="col_title">
-					<h1><?% title %?></h1>
+					<h1>
+						<?% title %?>
+					</h1>
 				</td>
 			</tr>
 		</table>
 	</form>
 
 	<?% IF matches.size() > 0 %?>
-		<table width="100%" border="0" cellspacing="0" cellpadding="0" class="list" id="content">
-			<!--
+	<table width="100%" border="0" cellspacing="0" cellpadding="0" class="list" id="content">
+		<!--
 			<tr class="heading">
 				<td class="col_duration"><h2><?% gettext('Duration') %?></h2></td>
 				<td class="col_center"><h2><?% gettext('Title') %?></h2></td>
@@ -233,51 +278,65 @@
 				<td class="col_buttons"></td>
 			</tr>
 			-->
-			<?% FOREACH matches;
+		<?% FOREACH matches;
 				IF olddate != date;
 					olddate = date; %?>
-					<tr class="newday">
-						<td colspan="5"><span class="date_long"><?% date %?></span></td>
-					</tr>
+		<tr class="newday">
+			<td colspan="5"><span class="date_long">
+					<?% date %?>
+				</span></td>
+		</tr>
+		<?% END %?>
+		<tr class="<?% IF loop.count % 2 == 0 %?>row_even<?% ELSE %?>row_odd<?% END %?>">
+			<td class="col_duration">
+				<span class="time_duration"><span class="time_start">
+						<?% start %?>
+					</span> - <span class="time_stop">
+						<?% stop %?>
+					</span></span>
+			</td>
+			<td class="col_center">
+				<div class="epg_title">
+					<?% IF infurl %?>
+					<a href="javascript:popup('<?% infurl %?>', <?% config.GUI_POPUP_WIDTH %?>, <?% config.GUI_POPUP_HEIGHT %?>);"
+						title="<?% gettext('More Information') %?>">
+						<?% END %?>
+						<?% title %?>
+						<?% IF infurl %?>
+					</a>
+					<?% END %?>
+				</div>
+				<?% IF subtitle %?>
+				<div class="epg_subtitle">
+					<?% subtitle %?>
+				</div>
+				<?% ELSE %?>
+				<div class="epg_subtitle">&nbsp;</div>
 				<?% END %?>
-				<tr class="<?% IF loop.count % 2 == 0 %?>row_even<?% ELSE %?>row_odd<?% END %?>">
-					<td class="col_duration">
-						<span class="time_duration"><span class="time_start"><?% start %?></span> - <span class="time_stop"><?% stop %?></span></span>
-					</td>
-					<td class="col_center">
-						<div class="epg_title">
-							<?% IF infurl %?>
-								<a href="javascript:popup('<?% infurl %?>', <?% config.GUI_POPUP_WIDTH %?>, <?% config.GUI_POPUP_HEIGHT %?>);" title="<?% gettext('More Information') %?>">
-							<?% END %?>
-							<?% title %?>
-							<?% IF infurl %?>
-								</a>
-							<?% END %?>
-						</div>
-						<?% IF subtitle %?>
-							<div class="epg_subtitle"><?% subtitle %?></div>
-						<?% ELSE %?>
-							<div class="epg_subtitle">&nbsp;</div>
-						<?% END %?>
-					</td>
-					<td class="col_channel">
-						<div class="channel_name"><a href="<?% proglink %?>" title="<?% gettext('Channels') %?>"><?% channel %?></a></div>
-					</td>
-					<td class="col_folder">
-						<?% folder %?>
-					</td>
-					<td class="col_folder">
-						<?% IF recurl %?>
-							<span class="action record"><a href="<?% recurl %?>"><img src="bilder/rec_button.png" border="0" alt="record" title="<?% gettext('Record') %?>" /></a></span>
-						<?% END %?>
-					</td>
-				</tr>
-			<?% END %?>
-		</table>
+			</td>
+			<td class="col_channel">
+				<div class="channel_name"><a href="<?% proglink %?>" title="<?% gettext('Channels') %?>">
+						<?% channel %?>
+					</a></div>
+			</td>
+			<td class="col_folder">
+				<?% folder %?>
+			</td>
+			<td class="col_folder">
+				<?% IF recurl %?>
+				<span class="action record"><a href="<?% recurl %?>"><img src="bilder/rec_button.png" border="0"
+							alt="record" title="<?% gettext('Record') %?>" /></a></span>
+				<?% END %?>
+			</td>
+		</tr>
+		<?% END %?>
+	</table>
 	<?% ELSE %?>
-		<div class="warning"><?% gettext('No matches found!') %?></div>
+	<div class="warning">
+		<?% gettext('No matches found!') %?>
+	</div>
 	<?% END %?>
-<?% END %?>
+	<?% END %?>
 </body>
 
 </html>

--- a/template/default/style.css
+++ b/template/default/style.css
@@ -458,7 +458,7 @@ body.help .heading {
 	width: 100px;
 	vertical-align: top;
 }
-	
+
 .col_name,
 #content .col_title * {
 	padding-left: 3px;
@@ -472,7 +472,7 @@ body.help .heading {
 	text-align: center;
 }
 .col_active {
-	width: 90px;
+	width: 75px;
 }
 .col_channel {
 	width: 120px;
@@ -481,11 +481,11 @@ body.help .heading {
 .col_stop,
 .col_date,
 .col_time {
-	width: 76px;
+	width: 75px;
 	text-align: left;
 }
 .col_length {
-	width: 76px;
+	width: 75px;
 	text-align: right;
 }
 .col_edit,
@@ -494,6 +494,11 @@ body.help .heading {
 .col_checkbox {
 	text-align: center;
 	width: 16px;
+}
+.col_pattern {
+	padding-left: 3px;
+    padding-right: 3px;
+	min-width: 120px;
 }
 
 #heading {

--- a/template/default/timer_list.html
+++ b/template/default/timer_list.html
@@ -1,37 +1,45 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<!DOCTYPE html
+	PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html id="scroller">
 
 <head>
 	<meta http-equiv="content-type" content="text/html;charset=<?% charset %?>" />
-	<title>VDRAdmin-AM - <?% gettext('Timer') %?></title>
+	<title>VDRAdmin-AM -
+		<?% gettext('Timer') %?>
+	</title>
 	<link href="style.css" rel="stylesheet" media="screen" type="text/css" />
 	<?% IF usercss %?>
-		<link href="user.css" rel="stylesheet" media="screen" type="text/css" />
+	<link href="user.css" rel="stylesheet" media="screen" type="text/css" />
 	<?% END %?>
 	<script type="text/javascript" language="JavaScript1.2" src="library.js"></script>
 	<?% IF config.TM_TT_TIMELINE || config.TM_TT_LIST %?>
-		<script type="text/javascript" language="JavaScript1.2" src="infobox.js"></script>
+	<script type="text/javascript" language="JavaScript1.2" src="infobox.js"></script>
 	<?% END %?>
 	<style type="text/css">
-		.prgtable { border-left-width:1px; border-left-style:solid; border-right-width:1px; border-right-style:solid; }
+		.prgtable {
+			border-left-width: 1px;
+			border-left-style: solid;
+			border-right-width: 1px;
+			border-right-style: solid;
+		}
 	</style>
 </head>
 
 <body id="timer_list">
-<?% IF config.TM_TT_TIMELINE || config.TM_TT_LIST %?>
+	<?% IF config.TM_TT_TIMELINE || config.TM_TT_LIST %?>
 	<div id="infodiv" style="position:absolute; visibility:hidden; z-index:20; top:0px; left:0px;"></div>
 	<script language="JavaScript" type="text/javascript">
 	<?%
-		FOREACH timer = timers2;
+			FOREACH timer = timers2;
 	%?>
-		maketip("VDR-<?% timer.id %?>", "<?% timer.title %?>", "<?% gettext('Priority:') %?> <?% timer.prio %?><br /><?% gettext('Lifetime:') %?> <?% timer.lft %?><br /><?% gettext('Duration:') %?> <?% timer.start %?> - <?% timer.stop %?> (<?% timer.duration %?><?% gettext('min') %?>)<br /><?% gettext('Transponder:') %?> <?% timer.transponder %?><br /><?% gettext('CA-System:') %?> <?% timer.ca %?>" );
+			maketip("VDR-<?% timer.id %?>", "<?% timer.title %?>", "<?% gettext('Priority:') %?> <?% timer.prio %?><br /><?% gettext('Lifetime:') %?> <?% timer.lft %?><br /><?% gettext('Duration:') %?> <?% timer.start %?> - <?% timer.stop %?> (<?% timer.duration %?><?% gettext('min') %?>)<br /><?% gettext('Transponder:') %?> <?% timer.transponder %?><br /><?% gettext('CA-System:') %?> <?% timer.ca %?>");
 	<?%
-  	END;
+			END;
 	%?>
 	</script>
-<?% END %?>
+	<?% END %?>
 
-<?%
+	<?%
 	datumold="";
 	senderold="";
 	faktor=2.2;
@@ -40,46 +48,68 @@
 	<form action="<?% url %?>" method="get" name="FormName0">
 		<table width="100%" border="0" cellspacing="0" cellpadding="0" id="heading">
 			<tr>
-				<td class="col_title"><h1><?% gettext('Timer') %?></h1></td>
+				<td class="col_title">
+					<h1>
+						<?% gettext('Timer') %?>
+					</h1>
+				</td>
 				<td class="col_other">
-					<input type="submit" class="submit" value="<?% gettext('New Timer') %?>" name="new_timer"/>
-					<input type="hidden" name="aktion" value="timer_new_form"/>
+					<input type="submit" class="submit" value="<?% gettext('New Timer') %?>" name="new_timer" />
+					<input type="hidden" name="aktion" value="timer_new_form" />
 				</td>
-<?% IF help_url %?> 
+				<?% IF help_url %?>
 				<td class="col_help">
-					<a href="javascript:open_help('<?% help_url %?>');"><img src="bilder/help.png" border="0" alt="help" title="<?% gettext('Help') %?>" /></a>
+					<a href="javascript:open_help('<?% help_url %?>');"><img src="bilder/help.png" border="0" alt="help"
+							title="<?% gettext('Help') %?>" /></a>
 				</td>
-<?% END %?>
+				<?% END %?>
 			</tr>
 		</table>
 	</form>
 
-<?% IF error_msg %?>
-		<div class="error"><?% error_msg %?></div>
-<?% END %?>
+	<?% IF error_msg %?>
+	<div class="error">
+		<?% error_msg %?>
+	</div>
+	<?% END %?>
 
 	<div id="content">
-<?% IF timers.size() > 0 %?>
+		<?% IF timers.size() > 0 %?>
 		<form action="<?% url %?>" method="get" name="FormName1">
 			<table width="100%" border="0" cellspacing="0" cellpadding="0" class="list">
 				<tr class="heading">
-					<td><h2><?% title %?></h2></td>
+					<td>
+						<h2>
+							<?% title %?>
+						</h2>
+					</td>
 					<td class="col_navi">
-						<?% IF prevdayurl %?><a href="<?% prevdayurl %?>" title="<?% prevdaytext %?>"><img src="bilder/pfeile_nachlinks.png" border="0" alt="" /></a><?% ELSE %?><img src="bilder/pfeile_nachlinks_soft.png" border="0" alt="" /><?% END %?>
-						<select name="vdr_id" class="submit" onchange="window.open('<?% url %?>?aktion=timer_list&amp;timer=' + this.options[this.selectedIndex].value,'main')">
-	<?% FOREACH day = day_loop %?>
-							<option value="<?% day.sortfield | html %?>" <?% IF day.current %?>selected="selected"<?% END %?>><?% day.day %?></option>
-	<?% END %?>
+						<?% IF prevdayurl %?><a href="<?% prevdayurl %?>" title="<?% prevdaytext %?>"><img
+								src="bilder/pfeile_nachlinks.png" border="0" alt="" /></a>
+						<?% ELSE %?><img src="bilder/pfeile_nachlinks_soft.png" border="0" alt="" />
+						<?% END %?>
+						<select name="vdr_id" class="submit"
+							onchange="window.open('<?% url %?>?aktion=timer_list&amp;timer=' + this.options[this.selectedIndex].value,'main')">
+							<?% FOREACH day = day_loop %?>
+							<option value="<?% day.sortfield | html %?>" <?% IF day.current %?>selected="selected"
+								<?% END %?>>
+								<?% day.day %?>
+							</option>
+							<?% END %?>
 						</select>
-						<?% IF nextdayurl %?><a href="<?% nextdayurl %?>" title="<?% nextdaytext %?>"><img src="bilder/pfeile_nachrechts.png" border="0" alt="" /></a><?% ELSE %?><img src="bilder/pfeile_nachrechts_soft.png" border="0" alt="" /><?% END %?>
+						<?% IF nextdayurl %?><a href="<?% nextdayurl %?>" title="<?% nextdaytext %?>"><img
+								src="bilder/pfeile_nachrechts.png" border="0" alt="" /></a>
+						<?% ELSE %?><img src="bilder/pfeile_nachrechts_soft.png" border="0" alt="" />
+						<?% END %?>
 					</td>
 				</tr>
 				<tr class="row_even">
 					<td colspan="2" align="center">
 						<table cellspacing="0" cellpadding="0" border="0">
 							<tr>
-								<td class="color1" height="20" width="100"><img src="bilder/spacer.gif" width="100" height="1" border="0" alt="" /><br />&nbsp;</td>
-	<?%
+								<td class="color1" height="20" width="100"><img src="bilder/spacer.gif" width="100"
+										height="1" border="0" alt="" /><br />&nbsp;</td>
+								<?%
 		stunde=0;
 		pos=0;
 		WHILE stunde<24;
@@ -87,15 +117,19 @@
 			ende=((stunde * 60 / faktor) +0.5 ) | format('%i');
 	%?>
 
-								<td class="<?% (stunde % 2) == 1 ? 'color2' : 'color1' %?>" align="center"><img src="bilder/spacer.gif" width="<?% ende-pos %?>" height="1" border="0" alt="" /><br /><?% stunde - 1 %?></td>
-	<?%
+								<td class="<?% (stunde % 2) == 1 ? 'color2' : 'color1' %?>" align="center"><img
+										src="bilder/spacer.gif" width="<?% ende-pos %?>" height="1" border="0"
+										alt="" /><br />
+									<?% stunde - 1 %?>
+								</td>
+								<?%
 			pos=ende;
 		END;
 	%?>
 							</tr>
 						</table>
 
-	<?%
+						<?%
 		programm=0;
 		sender="";
 		tablaenge=((1440 / faktor) + 0.5 ) | format('%i');
@@ -105,9 +139,13 @@
 	%?>
 						<table cellspacing="0" cellpadding="0" border="0" class="timers">
 							<tr>
-								<td class="<?% (programm % 2) == 0 ? 'color2' : 'color1' %?>" height="20" width="100"><img src="bilder/spacer.gif" width="100" height="1" border="0" alt="" /><br /><a href="<?% timer.proglink %?>"><b><?% my_truncate(sender, 11) %?></b></a></td>
+								<td class="<?% (programm % 2) == 0 ? 'color2' : 'color1' %?>" height="20" width="100">
+									<img src="bilder/spacer.gif" width="100" height="1" border="0" alt="" /><br /><a
+										href="<?% timer.proglink %?>"><b>
+											<?% my_truncate(sender, 11) %?>
+										</b></a></td>
 
-	<?%
+								<?%
 				pos=0;
 				FOREACH sendung = timers;
 					IF sendung.cdesc == sender && sendung.starttime <= current && sendung.stoptime >= current;
@@ -138,35 +176,49 @@
 
 						IF start>pos;
 	%?>
-								<td class="<?% (programm % 2) == 0 ? 'color2' : 'color1' %?>"><img src="bilder/spacer.gif" width="<?% start-pos %?>" height="1" border="0" alt="" /><br /></td>
+								<td class="<?% (programm % 2) == 0 ? 'color2' : 'color1' %?>"><img
+										src="bilder/spacer.gif" width="<?% start-pos %?>" height="1" border="0"
+										alt="" /><br /></td>
 
-	<?%
+								<?%
 							pos=start;
 						END;
 						IF ende - pos < 2;
 	%?>
-								<td class="<?% td_class %?>"><span <?% IF config.TM_TT_TIMELINE %?>onmouseover="tip('VDR-<?% sendung.id %?>'); return true;" onmouseout="untip(); return true;"<?% END %?>><img src="bilder/spacer.gif" width="<?% ende - pos %?>" height="20" border="0" alt="" /></span></td>
+								<td class="<?% td_class %?>"><span <?% IF config.TM_TT_TIMELINE
+										%?>onmouseover="tip('VDR-
+										<?% sendung.id %?>'); return true;" onmouseout="untip(); return true;"
+										<?% END %?>><img src="bilder/spacer.gif" width="<?% ende - pos %?>" height="20"
+											border="0" alt="" />
+									</span></td>
 
-	<?%
+								<?%
 						ELSE;
 	%?>
-								<td class="<?% td_class %?> prgtable"><span <?% IF config.TM_TT_TIMELINE %?>onmouseover="tip('VDR-<?% sendung.id %?>'); return true;" onmouseout="untip(); return true;"<?% END %?>><img src="bilder/spacer.gif" width="<?% ende - pos - 2 %?>" height="20" border="0" alt="" /></span></td>
+								<td class="<?% td_class %?> prgtable"><span <?% IF config.TM_TT_TIMELINE
+										%?>onmouseover="tip('VDR-
+										<?% sendung.id %?>'); return true;" onmouseout="untip(); return true;"
+										<?% END %?>><img src="bilder/spacer.gif" width="<?% ende - pos - 2 %?>"
+											height="20" border="0" alt="" />
+									</span></td>
 
-	<?%
+								<?%
 						END;
 						pos=ende;
 					END;
 				END;
 				IF pos<tablaenge;
 	%?>
-								<td class="<?% (programm % 2) == 0 ? 'color2' : 'color1' %?>"><img src="bilder/spacer.gif" width="<?% tablaenge - pos %?>" height="1" border="0" alt="" /><br /></td>
+								<td class="<?% (programm % 2) == 0 ? 'color2' : 'color1' %?>"><img
+										src="bilder/spacer.gif" width="<?% tablaenge - pos %?>" height="1" border="0"
+										alt="" /><br /></td>
 
-	<?%
+								<?%
 				END;
 	%?>
 							</tr>
 						</table>
-	<?%
+						<?%
 				programm=programm+1;
 			END;
 	  END;
@@ -194,154 +246,220 @@
 				<tr class="heading">
 					<td class="col_active <?% IF sortbyactive %?>selected<?% END %?>">
 						<h2>
-							<a href="<?% sortbyactiveurl %?>"><?% gettext('Active') %?>
+							<a href="<?% sortbyactiveurl %?>">
+								<?% gettext('Active') %?>
 								<?% IF sortbyactive %?>
-									<img src="bilder/sortiert_<?% desc %?>.gif" alt="" width="9" height="11" border="0" />
+								<img src="bilder/sortiert_<?% desc %?>.gif" alt="" width="9" height="11" border="0" />
 								<?% ELSE %?>
-									<img src="bilder/spacer.gif" alt="" width="9" height="11" border="0" />
+								<img src="bilder/spacer.gif" alt="" width="9" height="11" border="0" />
 								<?% END %?>
 							</a>
 						</h2>
 					</td>
 					<td class="col_channel <?% IF sortbychannel %?>selected<?% END %?>">
 						<h2>
-							<a href="<?% sortbychannelurl %?>"><?% gettext('Channel') %?>
+							<a href="<?% sortbychannelurl %?>">
+								<?% gettext('Channel') %?>
 								<?% IF sortbychannel %?>
-									<img src="bilder/sortiert_<?% desc %?>.gif" alt="" width="9" height="11" border="0" />
+								<img src="bilder/sortiert_<?% desc %?>.gif" alt="" width="9" height="11" border="0" />
 								<?% ELSE %?>
-									<img src="bilder/spacer.gif" alt="" width="9" height="11" border="0" />
+								<img src="bilder/spacer.gif" alt="" width="9" height="11" border="0" />
 								<?% END %?>
 							</a>
 						</h2>
 					</td>
 					<td class="col_date <?% IF sortbyday %?>selected<?% END %?>">
 						<h2>
-							<a href="<?% sortbydayurl %?>"><?% gettext('Date') %?>
+							<a href="<?% sortbydayurl %?>">
+								<?% gettext('Date') %?>
 								<?% IF sortbyday %?>
-									<img src="bilder/sortiert_<?% desc %?>.gif" alt="" width="9" height="11" border="0" />
+								<img src="bilder/sortiert_<?% desc %?>.gif" alt="" width="9" height="11" border="0" />
 								<?% ELSE %?>
-									<img src="bilder/spacer.gif" alt="" width="9" height="11" border="0" />
+								<img src="bilder/spacer.gif" alt="" width="9" height="11" border="0" />
 								<?% END %?>
 							</a>
 						</h2>
 					</td>
 					<td class="col_start <?% IF sortbystart %?>selected<?% END %?>">
 						<h2>
-							<a href="<?% sortbystarturl %?>"><?% gettext('Start') %?>
+							<a href="<?% sortbystarturl %?>">
+								<?% gettext('Start') %?>
 								<?% IF sortbystart %?>
-									<img src="bilder/sortiert_<?% desc %?>.gif" alt="" width="9" height="11" border="0" />
+								<img src="bilder/sortiert_<?% desc %?>.gif" alt="" width="9" height="11" border="0" />
 								<?% ELSE %?>
-									<img src="bilder/spacer.gif" alt="" width="9" height="11" border="0" />
+								<img src="bilder/spacer.gif" alt="" width="9" height="11" border="0" />
 								<?% END %?>
 							</a>
 						</h2>
 					</td>
 					<td class="col_stop <?% IF sortbystop %?>selected<?% END %?>">
 						<h2>
-							<a href="<?% sortbystopurl %?>"><?% gettext('Stop') %?>
+							<a href="<?% sortbystopurl %?>">
+								<?% gettext('Stop') %?>
 								<?% IF sortbystop %?>
-									<img src="bilder/sortiert_<?% desc %?>.gif" alt="" width="9" height="11" border="0" />
+								<img src="bilder/sortiert_<?% desc %?>.gif" alt="" width="9" height="11" border="0" />
 								<?% ELSE %?>
-									<img src="bilder/spacer.gif" alt="" width="9" height="11" border="0" />
+								<img src="bilder/spacer.gif" alt="" width="9" height="11" border="0" />
 								<?% END %?>
 							</a>
 						</h2>
 					</td>
 					<td class="col_name <?% IF sortbyname %?>selected<?% END %?>">
 						<h2>
-							<a href="<?% sortbynameurl %?>"><?% gettext('Name') %?>
+							<a href="<?% sortbynameurl %?>">
+								<?% gettext('Name') %?>
 								<?% IF sortbyname %?>
-									<img src="bilder/sortiert_<?% desc %?>.gif" alt="" width="9" height="11" border="0" />
+								<img src="bilder/sortiert_<?% desc %?>.gif" alt="" width="9" height="11" border="0" />
 								<?% ELSE %?>
-									<img src="bilder/spacer.gif" alt="" width="9" height="11" border="0" />
+								<img src="bilder/spacer.gif" alt="" width="9" height="11" border="0" />
+								<?% END %?>
+							</a>
+						</h2>
+					</td>
+					<td class="col_pattern <?% IF sortbypattern %?>selected<?% END %?>">
+						<h2>
+							<a href="<?% sortbypatternurl %?>">
+								<?% gettext('Search pattern') %?>
+								<?% IF sortbypattern %?>
+								<img src="bilder/sortiert_<?% desc %?>.gif" alt="" width="9" height="11" border="0" />
+								<?% ELSE %?>
+								<img src="bilder/spacer.gif" alt="" width="9" height="11" border="0" />
 								<?% END %?>
 							</a>
 						</h2>
 					</td>
 					<td class="col_edit"></td>
 					<td class="col_delete"></td>
-					<td class="col_checkbox"><input type="checkbox" name="SELALL" value="SELALL" onclick="AllMessages(this.form);" title="<?% gettext('Select all/none') %?>" /></td>
+					<td class="col_checkbox"><input type="checkbox" name="SELALL" value="SELALL"
+							onclick="AllMessages(this.form);" title="<?% gettext('Select all/none') %?>" /></td>
 				</tr>
 
-	<?% FOREACH timer = timer_loop %?>
+
+				<?% FOREACH timer = timer_loop %?>
 				<tr class="<?% IF loop.count() % 2 == 0 %?>row_even<?% ELSE %?>row_odd<?% END %?>">
 					<td class="col_active <?% IF timer.sortbyactive %?>selected<?% END %?>">
 						<div>
-							<a href="javascript:change('<?% gettext('Edit timer status?') %?>','<?% timer.toggleurl %?>&amp;timer=<?% timer.current %?>');">
-							<?% IF timer.active % 32768 == 0 %?>
-								<img src="bilder/poempl_grau.png" alt="inactive" title="<?% gettext('This timer is inactive!') %?>" align="middle" border="0" />
-							<?% ELSE %?>
-								<?% IF timer.critical %?>
-									<img src="bilder/poempl_rot.png" alt="impossible" title="<?% gettext('This timer is impossible!') %?>" align="middle" border="0" />
+							<a
+								href="javascript:change('<?% gettext('Edit timer status?') %?>','<?% timer.toggleurl %?>&amp;timer=<?% timer.current %?>');">
+								<?% IF timer.active % 32768 == 0 %?>
+								<img src="bilder/poempl_grau.png" alt="inactive"
+									title="<?% gettext('This timer is inactive!') %?>" align="middle" border="0" />
 								<?% ELSE %?>
-									<?% IF timer.collision %?>
-										<img src="bilder/poempl_gelb.png" alt="nomore" title="<?% gettext('No more timers on other transponders possible!') %?>" align="middle" border="0" />
-									<?% ELSE %?>
-										<?% IF timer.active %?>
-											<img src="bilder/poempl_gruen.png" alt="possible" title="<?% gettext('Timer OK.') %?>" align="middle" border="0" />
-										<?% END %?>
-									<?% END %?>
+								<?% IF timer.critical %?>
+								<img src="bilder/poempl_rot.png" alt="impossible"
+									title="<?% gettext('This timer is impossible!') %?>" align="middle" border="0" />
+								<?% ELSE %?>
+								<?% IF timer.collision %?>
+								<img src="bilder/poempl_gelb.png" alt="nomore"
+									title="<?% gettext('No more timers on other transponders possible!') %?>"
+									align="middle" border="0" />
+								<?% ELSE %?>
+								<?% IF timer.active %?>
+								<img src="bilder/poempl_gruen.png" alt="possible" title="<?% gettext('Timer OK.') %?>"
+									align="middle" border="0" />
 								<?% END %?>
-							<?% END %?>
-								<?% IF timer.active == 1  %?><?% gettext('Yes') %?><?% END %?>
-								<?% IF timer.active == 0 %?><?% gettext('No') %?><?% END %?>
-								<?% IF timer.active == 5 %?><?% gettext('VPS') %?><?% END %?>
-								<?% IF timer.autotimer %?>(<?% gettext('Auto') %?>)<?% END %?>
+								<?% END %?>
+								<?% END %?>
+								<?% END %?>
+								<?% IF timer.active == 1  %?>
+								<?% gettext('Yes') %?>
+								<?% END %?>
+								<?% IF timer.active == 0 %?>
+								<?% gettext('No') %?>
+								<?% END %?>
+								<?% IF timer.active == 5 %?>
+								<?% gettext('VPS') %?>
+								<?% END %?>
+								<?% IF timer.autotimer %?>(
+								<?% gettext('Auto') %?>)
+								<?% END %?>
 							</a>
 						</div>
 					</td>
 					<td class="col_channel <?% IF timer.sortbychannel %?>selected<?% END %?>">
-						<div><a href="<?% timer.proglink %?>"><?% timer.cdesc %?></a></div>
+						<div><a href="<?% timer.proglink %?>">
+								<?% timer.cdesc %?>
+							</a></div>
 					</td>
 					<td class="col_date <?% IF timer.sortbyday %?>selected<?% END %?>">
-						<div><?% timer.dor %?></div>
+						<div>
+							<?% timer.dor %?>
+						</div>
 					</td>
 					<td class="col_start <?% IF timer.sortbystart %?>selected<?% END %?>">
-						<div><?% timer.start %?></div>
+						<div>
+							<?% timer.start %?>
+						</div>
 					</td>
 					<td class="col_stop <?% IF timer.sortbystop %?>selected<?% END %?>">
-						<div><?% timer.stop %?></div>
+						<div>
+							<?% timer.stop %?>
+						</div>
 					</td>
 					<td class="col_name <?% IF timer.sortbyname %?>selected<?% END %?>">
-						<div <?% IF config.TM_TT_LIST %?>onmouseover="tip('VDR-<?% timer.id %?>'); return true;" onmouseout="untip(); return true;"<?% END %?>>
-							<?% IF timer.recording && timer.active %?><img align="middle" src="bilder/rec.gif" border="0" alt="" />&nbsp;<?% END %?>
+						<div <?% IF config.TM_TT_LIST %?>onmouseover="tip('VDR-
+							<?% timer.id %?>'); return true;" onmouseout="untip(); return true;"
+							<?% END %?>>
+							<?% IF timer.recording && timer.active %?><img align="middle" src="bilder/rec.gif"
+								border="0" alt="" />&nbsp;
+							<?% END %?>
 							<?% IF timer.infurl %?>
-								<a href="javascript:popup('<?% timer.infurl %?>', <?% config.GUI_POPUP_WIDTH %?>, <?% config.GUI_POPUP_HEIGHT %?>);"><?% timer.title %?></a>
-							<?% ELSE %?>
+							<a
+								href="javascript:popup('<?% timer.infurl %?>', <?% config.GUI_POPUP_WIDTH %?>, <?% config.GUI_POPUP_HEIGHT %?>);">
 								<?% timer.title %?>
+							</a>
+							<?% ELSE %?>
+							<?% timer.title %?>
 							<?% END %?>
 						</div>
 					</td>
+					<td class="col_pattern">
+						<div>
+							<?% IF timer.pattern %?><?% timer.pattern | html %?><?% END %?>
+						</div>
+					</td>
 					<td class="col_edit">
-						<div><a href="<?% timer.modurl %?>"><img src="bilder/edit.png" alt="edit" title="<?% gettext('Edit') %?>" border="0" /></a></div>
+						<div><a href="<?% timer.modurl %?>"><img src="bilder/edit.png" alt="edit"
+									title="<?% gettext('Edit') %?>" border="0" /></a></div>
 					</td>
 					<td class="col_delete">
-						<div><a href="javascript:del('<?% gettext('Delete timer?') %?>\n\n&quot;<?% timer.title_js %?>&quot;','<?% timer.delurl %?>');"><img src="bilder/delete.png" alt="delete" title="<?% gettext('Delete') %?>" border="0" /></a></div>
+						<div><a
+href="javascript:del('<?% gettext('Delete timer?') %?>\n\n<?% timer.title_js %?>','<?% timer.delurl %?>');"><img
+									src="bilder/delete.png" alt="delete" title="<?% gettext('Delete') %?>"
+									border="0" /></a></div>
 					</td>
 					<td class="col_checkbox">
 						<div><input type="checkbox" name="xxxx_<?% timer.id %?>" /></div>
 					</td>
 				</tr>
-	<?% END %?>
+				<?% END %?>
 			</table>
 
 			<table width="100%" border="0" cellspacing="0" cellpadding="0" id="buttons">
 				<tr>
 					<td align="left">
-						<input type="submit" class="submit" name="timer_active" value="<?% gettext('activate') %?>" onclick="return confirm('<?% gettext('Edit timer status?') %?>');" />
-						<input type="submit" class="submit" name="timer_inactive" value="<?% gettext('inactivate') %?>" onclick="return confirm('<?% gettext('Edit timer status?') %?>');" />
-						&nbsp;<?% gettext('selected timers') %?>
+						<input type="submit" class="submit" name="timer_active" value="<?% gettext('activate') %?>"
+							onclick="return confirm('<?% gettext('Edit timer status?') %?>');" />
+						<input type="submit" class="submit" name="timer_inactive" value="<?% gettext('inactivate') %?>"
+							onclick="return confirm('<?% gettext('Edit timer status?') %?>');" />
+						&nbsp;
+						<?% gettext('selected timers') %?>
 					</td>
 					<td align="right">
-						<input type="submit" class="submit" name="timer_delete" value="<?% gettext('Delete Selected Timers') %?>" onclick="return mdel(this, '<?% gettext('Delete all selected timers?') %?>');" />
+						<input type="submit" class="submit" name="timer_delete"
+							value="<?% gettext('Delete Selected Timers') %?>"
+							onclick="return mdel(this, '<?% gettext('Delete all selected timers?') %?>');" />
 					</td>
 				</tr>
 			</table>
 			<input type="hidden" name="aktion" value="timer_aktion" />
 		</form>
-<?% ELSE %?>
-		<div class="warning"><?% gettext('No timers defined!') %?></div>
-<?% END %?>
+		<?% ELSE %?>
+		<div class="warning">
+			<?% gettext('No timers defined!') %?>
+		</div>
+		<?% END %?>
 	</div>
 </body>
+
 </html>

--- a/vdradmind.pl
+++ b/vdradmind.pl
@@ -5403,7 +5403,7 @@ sub encode_RecTitle {
         # VFAT on
         for ($i = 0 ; $i < length($title) ; $i++) {
             $c = substr($title, $i, 1);
-            unless ($c =~ /[�������A-Za-z0123456789_!@\$%&()+,.\-;=~ ]/) {
+            unless ($c =~ /[öäüßÖÄÜA-Za-z0123456789_!@\$%&()+,.\-;=~ ]/) {
                 $newtitle .= sprintf("#%02X", ord($c));
             } else {
                 $newtitle .= $c;

--- a/vdradmind.pl
+++ b/vdradmind.pl
@@ -112,12 +112,12 @@ use strict;
 #use warnings;
 
 my $SEARCH_FILES_IN_SYSTEM    = 0;
-my $VDR_MAX_SVDRP_LENGTH      = 10000;                        # validate this value
+my $VDR_MAX_SVDRP_LENGTH      = 10000;  # Validate this value
 my $SUPPORTED_LOCALE_PREFIXES = "^(cs|de|en|es|fi|fr|hu|it|nl|ru)_";
 
 my $TOOL_AUTOTIMER = 0;
 my $TOOL_EPGSEARCH = 1;
-my $TOOL_TVSCRAPER = 2; # TVScraper plugin also adds timer to improve recordings
+my $TOOL_TVSCRAPER = 2;  # TVScraper plugin also adds timer to improve recordings
 
 my $AT_BY_EVENT_ID = 2;
 my $AT_BY_TIME     = 1;
@@ -142,7 +142,7 @@ sub LOG_INFO ()       { [ 6, "info"    ] }
 sub LOG_DEBUG ()      { [ 7, "debug"   ] }
 
 my (%CONFIG, %CONFIG_TEMP);
-$CONFIG{LOGLEVEL}             = 5; #LOG_NOTICE
+$CONFIG{LOGLEVEL}             = 5;  # LOG_NOTICE
 $CONFIG{LOGGING}              = 0;
 $CONFIG{LOGFILE}              = "syslog";
 $CONFIG{MOD_GZIP}             = 0;
@@ -157,7 +157,7 @@ $CONFIG{HTTP_KEEPALIVE_TIMEOUT} = 10;
 
 #
 $CONFIG{VDR_HOST}   = "localhost";
-$CONFIG{VDR_PORT}   = 2001; # will be set to 6419 in initial --config if locally installed VDR is >= 1.7.15
+$CONFIG{VDR_PORT}   = 2001;  # Will be set to 6419 in initial --config if locally installed VDR is >= 1.7.15
 $CONFIG{SERVERHOST} = "0.0.0.0";
 $CONFIG{SERVERPORT} = 8001;
 $CONFIG{LOCAL_NET}  = "0.0.0.0/32";
@@ -219,7 +219,7 @@ $CONFIG{ST_FUNC}           = 1;
 $CONFIG{ST_REC_ON}         = 0;
 $CONFIG{ST_LIVE_ON}        = 1;
 $CONFIG{ST_URL}            = "";
-$CONFIG{ST_STREAMDEV_HOST} = ""; # streamdev/xineliboutput host
+$CONFIG{ST_STREAMDEV_HOST} = "";  # streamdev/xineliboutput host
 $CONFIG{ST_STREAMDEV_PORT} = 3000;
 $CONFIG{ST_XINELIB_PORT}   = 37890;
 $CONFIG{ST_VIDEODIR}       = "";
@@ -232,7 +232,7 @@ $CONFIG{NO_EVENTID}    = 0;
 $CONFIG{NO_EVENTID_ON} = "";
 
 #
-$CONFIG{AT_SENDMAIL}    = 0;                       # set to 1 and set all the "MAIL_" things if you want email notification on new autotimers.
+$CONFIG{AT_SENDMAIL}    = 0;  # Set to 1 and set all the "MAIL_" things if you want email notification on new autotimers.
 chomp($CONFIG{MAIL_FROM} = 'autotimer@' . (`hostname -f 2>/dev/null` || "localhost.localdomain"));
 $CONFIG{MAIL_TO}        = "you\@example.org";
 $CONFIG{MAIL_SERVER}    = "localhost";
@@ -277,7 +277,7 @@ my %FEATURES;
 $FEATURES{STREAMDEV}            = 0;  # streamdev plugin available?
 $FEATURES{XINELIB}              = 0;  # xineliboutput plugin available?
 $FEATURES{REC_RENAME}           = 0;  # RENR/MOVR patch available?
-$FEATURES{AUTOTIMER}            = 0;  # use autotimer feature?
+$FEATURES{AUTOTIMER}            = 0;  # Use autotimer feature?
 $FEATURES{MYVERSION_HR}         = "$VERSION";  # Human readable VDRAdmin-AM version, e.g. 3.6.5
 $FEATURES{VDRVERSION}           = 0;  # Numeric VDR version, e.g. 10344
 $FEATURES{VDRVERSION_HR}        = ''; # Human readable VDR version, e.g. 1.3.44
@@ -324,7 +324,7 @@ textdomain("vdradmin");
 my $UserCSS;
 $UserCSS = "user.css" if (-e "$USER_CSS");
 
-my $USE_SHELL_GZIP = false;          # set on false to use the gzip library
+my $USE_SHELL_GZIP = false;  # Set to false to use the gzip library
 
 my (%EPG, %CHAN, %CHAN_TABLES, $q, $ACCEPT_GZIP, $SVDRP, $low_time, @RECORDINGS);
 my (%RECORDING_FOLDERS, %RECORDING_BY_ID);
@@ -412,7 +412,7 @@ for (my $i = 0 ; $i < scalar(@ARGV) ; $i++) {
         my $pid = getPID($PIDFILE);
         my $killed = defined($pid) ? kill(2, $pid) : -1;
         sleep(1);
-        if ($killed > 0 && -e $PIDFILE) { # Not deleted by kill/Shutdown()?
+        if ($killed > 0 && -e $PIDFILE) {  # Not deleted by kill/Shutdown()?
             unlink($PIDFILE) or Log(LOG_WARNING, "Can't delete pid file '$PIDFILE': $!");
         }
         exit($killed > 0 ? 0 : 1);
@@ -499,16 +499,16 @@ my $Xtemplate_vars = { usercss  => $UserCSS,
 };
 
 my $Xconfig = {
-    START_TAG    => '\<\?\%',                   # tag style
-    END_TAG      => '\%\?\>',                   # tag style
-    INCLUDE_PATH => $TEMPLATEDIR,               # or list ref
-    INTERPOLATE  => 0,                          # expand "$var" in plain text
-    PRE_CHOMP    => 1,                          # cleanup whitespace
-    POST_CHOMP   => 1,                          # cleanup whitespace
-    EVAL_PERL    => 1,                          # evaluate Perl code blocks
-    COMPILE_EXT  => 'cache',                    # tuning for templates
-    COMPILE_DIR  => $TEMPLATECACHE,             # tuning for templates
-    STAT_TTL     => 3600,                       # tuning for templates
+    START_TAG    => '\<\?\%',                   # Tag style
+    END_TAG      => '\%\?\>',                   # Tag style
+    INCLUDE_PATH => $TEMPLATEDIR,               # Or list ref
+    INTERPOLATE  => 0,                          # Expand "$var" in plain text
+    PRE_CHOMP    => 1,                          # Cleanup whitespace
+    POST_CHOMP   => 1,                          # Cleanup whitespace
+    EVAL_PERL    => 1,                          # Evaluate Perl code blocks
+    COMPILE_EXT  => 'cache',                    # Tuning for templates
+    COMPILE_DIR  => $TEMPLATECACHE,             # Tuning for templates
+    STAT_TTL     => 3600,                       # Tuning for templates
     VARIABLES    => $Xtemplate_vars,
 
     # Developer options:
@@ -517,7 +517,7 @@ my $Xconfig = {
     #DEBUG        => DEBUG_ALL,
 };
 
-# create Template object
+# Create Template object
 my $Xtemplate;
 eval {
     $Xtemplate = Template->new($Xconfig);
@@ -545,7 +545,7 @@ if ($LOGGING && $LOGFILE eq "syslog") {
     }
 }
 if (!$LOG_TO_SYSLOG) {
-    *closelog = sub {}; # for Shutdown()
+    *closelog = sub {};  # For Shutdown()
 }
 
 if ($CONFIG{MOD_GZIP}) {
@@ -674,7 +674,7 @@ while (true) {
 
     my $now = time();
 
-    # update EPG
+    # Update EPG
     if ($n_ready == 0
             && ($CONFIG{CACHE_BG_UPDATE} == 1
                 || $CONFIG{AT_FUNC} && $FEATURES{AUTOTIMER}
@@ -700,12 +700,12 @@ while (true) {
             $c->{ttl} = undef;
             if (!$found) {
                 $found = $c;
-                # don't copy
+                # Don't copy
             } else {
                 push(@new, $c);
             }
         } else {
-            # no incoming data
+            # No incoming data
             if ($c->{ttl} && $now >= $c->{ttl}) {
                 Log(LOG_DEBUG, sprintf("[CLIENT(%d)] keep-alive timeout\n", $c->{socket}->fileno));
                 close($c->{socket});
@@ -717,7 +717,7 @@ while (true) {
     }
     @Connections = @new;
     next unless $found;
-    # move to the end
+    # Move to the end
     push(@Connections, $found);
     $Client = $found->{socket};
     undef $found;
@@ -777,7 +777,7 @@ sub processRequest {
     $Request =~ s|^/+|/|;
     local $ENV{HTTP_HOST};
 
-    # parse header
+    # Parse header
     my ($username, $password, $http_useragent);
     $Referer = $req->header("Referer");
     $ENV{HTTP_HOST} = $req->header("Host");
@@ -787,7 +787,7 @@ sub processRequest {
 
     my ($http_status, $bytes_transfered);
 
-    # authenticate
+    # Authenticate
     #print("Username: $username / Password: $password\n");
     my $checkpass = defined($username) && defined($password);
     if (($checkpass && $CONFIG{USERNAME} eq $username && $CONFIG{PASSWORD} eq $password)
@@ -801,7 +801,7 @@ sub processRequest {
         return;
     }
 
-    # serve request
+    # Serve request
     $SVDRP = SVDRP->new;
     $MyURL = "." . $Request;
     if ($Request eq "/vdradmin.pl" || $Request eq "/vdradmin." . $CONFIG{TV_EXT} || $Request eq "/vdradmin." . $CONFIG{REC_EXT}) {
@@ -939,7 +939,7 @@ sub check_rw_file {
     return 1;
 }
 
-sub GetChannelDesc {    #TODO: unused
+sub GetChannelDesc {    # TODO: unused
     my (%hash);
     for (@{$CHAN{$CHAN_FULL}->{channels}}) {
         $hash{ $_->{id} } = $_->{name};
@@ -992,7 +992,7 @@ sub ReadFile {
     return ($buf);
 }
 
-sub GetChannelID {    #TODO: unused
+sub GetChannelID {    # TODO: unused
     my ($sid) = $_[0];
     for (@{$CHAN{$CHAN_FULL}->{channels}}) {
         if ($_->{id} == $sid) {
@@ -1001,7 +1001,7 @@ sub GetChannelID {    #TODO: unused
     }
 }
 
-sub EURL {            #TODO: unused
+sub EURL {            # TODO: unused
     my ($text) = @_;
     $text =~ s/([^0-9a-zA-Z])/sprintf("%%%2.2x", ord($1))/ge;
     return ($text);
@@ -1014,7 +1014,7 @@ sub HTMLError {
     return showTemplate("error.html", $vars);
 }
 
-sub FillInZero {    #TODO: unused
+sub FillInZero {    # TODO: unused
     my ($str, $length) = @_;
     while (length($str) < $length) {
         $str = "0$str";
@@ -1038,7 +1038,7 @@ sub ChanTree {
     my $group_number = $CHAN_GROUPS - 1;
 
     if (!$FEATURES{VDRVERSION}) {
-        # first connection - have to get version
+        # First connection - have to get version
         $SVDRP->command("help");
         $SVDRP->readresponse;
     }
@@ -1061,7 +1061,7 @@ sub ChanTree {
             next;
         }
         my ($name, $frequency, $polarization, $source, $symbolrate, $vpid, $apid, $tpid, $ca, $service_id, $nid, $tid, $rid) = split(/\:/, $temp);
-        $name =~ /(^[^,;]*).*/;    #TODO?
+        $name =~ /(^[^,;]*).*/;    # TODO?
         $name = $1;
         my $uniq_id = $source . "-" . $nid . "-" . ($nid || $tid ? $tid : $frequency) . "-" . $service_id;
         $uniq_id .= "-" . $rid if ($rid != 0);
@@ -1120,7 +1120,7 @@ sub ChanTree {
         $CHAN{$CHAN_RADIO}->{channels} = \@CHANNELS_RADIO;
     }
 
-    # Temporarly disabled, because channellist also gets sorted by names. This causes duplicate channels appear side-by-side
+    # Temporarily disabled, because channellist also gets sorted by names. This causes duplicate channels appear side-by-side
     # Sort channel lists by channel name
     #foreach my $idx (keys(%CHAN)) {
     #    @{$CHAN{$idx}->{channels}} = sort {$a->{name} cmp $b->{name}} @{$CHAN{$idx}->{channels}}
@@ -1145,7 +1145,7 @@ sub getChannelGroups {
 
 sub get_vdrid_from_channelid {
     my $channel_id = shift;
-    if ($channel_id =~ /^(\d*)$/) {    # vdr 1.0.x & >= vdr 1.1.15
+    if ($channel_id =~ /^(\d*)$/) {  # vdr 1.0.x & >= vdr 1.1.15
         for my $channel (@{$CHAN{$CHAN_FULL}->{channels}}) {
             if ($channel->{service_id} == $1) {
                 return ($channel->{vdr_id});
@@ -1178,14 +1178,14 @@ sub get_name_from_uniqid {
     my $uniq_id = shift;
     if ($uniq_id) {
 
-        # Kanalliste nach identischer vdr_id durchsuchen
+        # Search channel list for identical vdr_id
         my @C = grep($_->{uniq_id} eq $uniq_id, @{$CHAN{$CHAN_FULL}->{channels}});
 #        foreach (@{$CHAN{$CHAN_FULL}->{channels}}) {
 #            printf("(%s) ($uniq_id)\n", $_->{uniq_id});
 #            return $_->{name} if ($_->{uniq_id} eq $uniq_id);
 #        }
 
-        # Es darf nach Spec nur eine �bereinstimmung geben
+        # There should be only one match according to the spec
         if (scalar(@C) == 1) {
             return $C[0]->{name};
         }
@@ -1196,10 +1196,10 @@ sub get_name_from_vdrid {
     my $vdr_id = shift;
     if ($vdr_id) {
 
-        # Kanalliste nach identischer vdr_id durchsuchen
+        # Search channel list for identical vdr_id
         my @C = grep($_->{vdr_id} == $vdr_id, @{$CHAN{$CHAN_FULL}->{channels}});
 
-        # Es darf nach Spec nur eine �bereinstimmung geben
+        # There should be only one match according to the spec
         if (scalar(@C) == 1) {
             return $C[0]->{name};
         }
@@ -1210,10 +1210,10 @@ sub get_channel_from_vdrid {
     my $vdr_id = shift;
     if ($vdr_id) {
 
-        # Kanalliste nach identischer vdr_id durchsuchen
+        # Search channel list for identical vdr_id
         my @C = grep($_->{vdr_id} == $vdr_id, @{$CHAN{$CHAN_FULL}->{channels}});
 
-        # Es darf nach Spec nur eine �bereinstimmung geben
+        # There should be only one match according to the spec
         if (scalar(@C) == 1) {
             return $C[0];
         }
@@ -1224,10 +1224,10 @@ sub get_transponder_from_vdrid {
     my $vdr_id = shift;
     if ($vdr_id) {
 
-        # Kanalliste nach identischer vdr_id durchsuchen
+        # Search channel list for identical vdr_id
         my @C = grep($_->{vdr_id} == $vdr_id, @{$CHAN{$CHAN_FULL}->{channels}});
 
-        # Es darf nach Spec nur eine �bereinstimmung geben
+        # There should be only one match according to the spec
         if (scalar(@C) == 1) {
             return ("$C[0]->{source}-$C[0]->{frequency}-$C[0]->{polarization}");
         }
@@ -1238,10 +1238,10 @@ sub get_ca_from_vdrid {
     my $vdr_id = shift;
     if ($vdr_id) {
 
-        # Kanalliste nach identischer vdr_id durchsuchen
+        # Search channel list for identical vdr_id
         my @C = grep($_->{vdr_id} == $vdr_id, @{$CHAN{$CHAN_FULL}->{channels}});
 
-        # Es darf nach Spec nur eine �bereinstimmung geben
+        # There should be only one match according to the spec
         if (scalar(@C) == 1) {
             return ($C[0]->{ca});
         }
@@ -1252,7 +1252,7 @@ sub get_ca_from_vdrid {
 # common helpers
 #############################################################################
 
-# remove spaces around string
+# Remove spaces around string
 sub trim($)
 {
     my $string = shift;
@@ -1261,7 +1261,7 @@ sub trim($)
     return $string;
 }
 
-# remove leading whitespaces from string
+# Remove leading whitespaces from string
 sub ltrim($)
 {
     my $string = shift;
@@ -1269,7 +1269,7 @@ sub ltrim($)
     return $string;
 }
 
-# remove trailing whitespaces from string
+# Remove trailing whitespaces from string
 sub rtrim($)
 {
     my $string = shift;
@@ -1277,7 +1277,7 @@ sub rtrim($)
     return $string;
 }
 
-# quotemeta() for $MY_ENCODING byte strings (with zero utf8 flag)
+# quotemeta() for $MY_ENCODING byte strings (With zero utf8 flag)
 sub my_quotemeta
 {
     my $str = shift;
@@ -1289,7 +1289,7 @@ sub my_quotemeta
     }
 }
 
-# case-insensitive compare on byte strings
+# Case-insensitive compare on byte strings
 sub ciCmp {
     my ($a, $b) = @_;
     if (utf8::is_utf8($a)) {
@@ -1332,7 +1332,7 @@ sub EPG_getEntry {
     }
 }
 
-sub getNumberOfElements {    #TODO: unused
+sub getNumberOfElements {  # TODO: Unused
     my $ref = shift;
     if ($ref) {
         return (@{$ref});
@@ -1373,7 +1373,7 @@ sub EPG_buildTree {
             my $vdr_id = get_vdrid_from_channelid($channel_id);
             if ($CONFIG{EPG_PRUNE} > 0 && $vdr_id > $CONFIG{EPG_PRUNE}) {
 
-                # diesen channel nicht einlesen
+                # Do not read this channel
                 while($_ = <$SOCK>) {
                     Encode::from_to($_, $from_charset, $to_charset) if ($recode);
                     last if (/^...-c/);
@@ -1386,7 +1386,7 @@ sub EPG_buildTree {
                     my $tok = substr($_, 3, 2);
                     my $rest = substr($_, 6);
                     if ($tok eq "-E") {
-                        # no need for chomp here - split() will take care
+                        # No need for chomp here - split() will take care
                         my ($event_id, $time, $duration) = split(/ /, $rest, 4);
                         my ($title, $subtitle, $summary, $vps);
                         my @stream_info = ();
@@ -1426,7 +1426,7 @@ sub EPG_buildTree {
                         }
                     }
                     elsif ($tok eq "-c") {
-                        if ($FEATURES{VDRVERSION} < 10305) { # EPG is sorted by date since VDR 1.3.5
+                        if ($FEATURES{VDRVERSION} < 10305) {  # EPG is sorted by date since VDR 1.3.5
                             my ($last) = 0;
                             my (@temp);
                             for (sort({ $a->[EV_START] <=> $b->[EV_START] } @events)) {
@@ -1598,7 +1598,7 @@ sub header {
         $resp->header('Cache-Control' => "public, max-age=3600");
     }
     if ($lastmod) {
-        $lastmod = $now if ($lastmod > $now); # HTTP 1.1, 14.29
+        $lastmod = $now if ($lastmod > $now);  # HTTP 1.1, 14.29
         $resp->header('Last-Modified' => time2str($lastmod));
     }
     $resp->header('Content-encoding' => "gzip") if ($CONFIG{MOD_GZIP} && $ACCEPT_GZIP);
@@ -1691,16 +1691,16 @@ sub SendFile {
 }
 
 #############################################################################
-# autotimer functions
+# Autotimer functions
 #############################################################################
 sub can_do_eventid_autotimer {
 
-    # check if we may use Event-IDs in general or not
+    # Check if we may use Event-IDs in general or not
     return 0 if ($CONFIG{NO_EVENTID} == 1);
 
     my $vdr_id = shift;
 
-    # check if the current channel is on the Event-ID-blacklist
+    # Check if the current channel is on the Event-ID-blacklist
     for my $n (split(",", $CONFIG{NO_EVENTID_ON})) {
         return 0 if ($n == $vdr_id);
     }
@@ -1840,18 +1840,17 @@ sub AutoTimer {
     $DONE = &DONE_Read unless ($DONE);
     my %blacklist = &BlackList_Read;
 
-    # Merken der wanted Channels (geht schneller
-    # bevor das immer wieder in der unteren Schleife gemacht wird).
+    # Remember the wanted channels (faster than doing it repeatedly in the loop below).
     my $wanted;
     for my $n (split(",", $CONFIG{CHANNELS_WANTED})) {
         $wanted->{$n} = 1;
     }
 
-    # Die Timerliste holen
-    #TODO: is this really needed? Timers will be checked in AT_ProgTimer...
+    # Get the timer list
+    # TODO: Is this really needed? Timers will be checked in AT_ProgTimer...
 #  my $timer;
 #  foreach my $t (ParseTimer(0)){
-##TODO: what's the 2nd "%s" for?
+# TODO: What's the 2nd "%s" for?
 #    my $key = sprintf('%d:%s:%s',
 #    $t->{vdr_id},
 #    $t->{title},
@@ -1870,18 +1869,16 @@ sub AutoTimer {
             # Event in the past?
             next if ($event->[EV_STOP] < $date_now);
 
-            # Ein Timer der schon programmmiert wurde kann
-            # ignoriert werden
-            #TODO: $timer not initialized
-#        next if($event->[EV_EVENT_ID] == $timer->{event_id});
+            # A timer that has already been programmed can be ignored
+            # TODO: $timer not initialized
+            #next if($event->[EV_EVENT_ID] == $timer->{event_id});
 
-            # Wenn CHANNELS_WANTED_AUTOTIMER dann next wenn der Kanal
-            # nicht in der WantedList steht
+            # If CHANNELS_WANTED_AUTOTIMER is set, skip if the channel is not in the wanted list
             if ($CONFIG{CHANNELS_WANTED_AUTOTIMER}) {
                 next unless defined $wanted->{ $event->[EV_VDR_ID] };
             }
 
-            # Hamwa schon gehabt?
+            # We had this already?
             my $DoneStr;
             unless ($dry_run) {
                 $DoneStr = sprintf('%s~%d~%s', $event->[EV_TITLE], $event->[EV_EVENT_ID], ($event->[EV_SUBTITLE] ? $event->[EV_SUBTITLE] : ''),);
@@ -1893,8 +1890,7 @@ sub AutoTimer {
             }
 
             if (%blacklist) {
-
-                # Wollen wir nicht haben.
+                # We do not want this
                 my $BLStr = $event->[EV_TITLE];
                 $BLStr .= "~" . $event->[EV_SUBTITLE] if $event->[EV_SUBTITLE];
 
@@ -1921,8 +1917,7 @@ sub AutoTimer {
                     $SearchStr .= "~" . $event->[EV_SUMMARY];
                 }
 
-                # Regular Expressions are surrounded by slashes -- everything else
-                # are search patterns
+                # Regular Expressions are surrounded by slashes -- everything else are search patterns
                 if ($at->{pattern} =~ /^\/(.*)\/(i?)$/) {
 
                     # We have a RegExp
@@ -1959,12 +1954,12 @@ sub AutoTimer {
                         next;
                     }
 
-                    # split search pattern at spaces into single sub-patterns, and
+                    # Split search pattern at spaces into single sub-patterns, and
                     # test for all of them (logical "and")
                     my $fp = 1;
                     for my $pattern (split(/ +/, $atpattern)) {
 
-                        # search for each sub-pattern, case insensitive
+                        # Search for each sub-pattern, case insensitive
                         if ($SearchStr !~ /$pattern/i) {
                             $fp = 0;
                         } else {
@@ -1979,8 +1974,8 @@ sub AutoTimer {
                 Log(LOG_DEBUG, sprintf("[AUTOTIMER] Comparing pattern \"%s\" (%s - %s) with event \"%s\" (%s - %s)", $at->{pattern}, $at->{start}, $at->{stop}, $event->[EV_TITLE], $event_start, $event_stop));
 
                 # Do we have a time slot?
-                if ($at->{start}) {    # We have a start time and possibly a stop time for the auto timer
-                                       # Do we have midnight between AT start and stop time?
+                if ($at->{start}) {  # We have a start time and possibly a stop time for the auto timer
+                                     # Do we have midnight between AT start and stop time?
                     if (($at->{stop}) && ($at->{stop} < $at->{start})) {
 
                         # The AT includes midnight
@@ -2070,7 +2065,7 @@ sub AutoTimer {
                 Log(LOG_DEBUG, sprintf("[AUTOTIMER] Found \"%s\"", $at->{pattern}));
 
 #########################################################################################
-# 20050130: patch by macfly: parse extended EPG information provided by tvm2vdr.pl
+# 20050130: Patch by macfly: Parse extended EPG information provided by tvm2vdr.pl
 #########################################################################################
 
                 my $title;
@@ -2112,15 +2107,15 @@ sub AutoTimer {
                     }
                 }
 
-                # gemaess vdr.5 alle : durch | ersetzen.
+    # According to vdr.5 replace all : with |.
                 $title =~ s#:#|#g;
 
-                # sind irgendwelche Tags verwendet worden, die leer waren und die doppelte Verzeichnisse erzeugten?
+    # Were any tags used that were empty and caused duplicate directories?
                 $title =~ s#~+#~#g;
                 $title =~ s#^~##;
 
 #########################################################################################
-# 20050130: patch by macfly: parse extended EPG information provided by tvm2vdr.pl
+# 20050130: Patch by macfly: Parse extended EPG information provided by tvm2vdr.pl
 #########################################################################################
 
                 if ($dry_run) {
@@ -2205,8 +2200,7 @@ sub AT_ProgTimer {
         }
     }
 
-    # we will only programm new timers, CheckTimers is responsible for
-    # updating existing timers
+    # We will only programm new timers, CheckTimers is responsible for updating existing timers
     if (!$found) {
         $title =~ s/\|/\:/g;
 
@@ -2239,10 +2233,10 @@ sub AT_ProgTimer {
         if ($CONFIG{AT_SENDMAIL} == 1 && $can_use_net_smtp && ($CONFIG{MAIL_AUTH_USER} eq "" || $can_use_smtpauth)) {
             my $sum = $summary;
 
-            # remove all HTML-Tags from text
+            # Remove all HTML-Tags from text
             $sum =~ s/\<[^\>]+\>/ /g;
 
-            # linefeeds
+            # Linefeeds
             $sum =~ s/\|/\n/g;
             my $dat  = strftime("%A, %x", localtime($start));
             my $strt = strftime("%H:%M",  localtime($start));
@@ -2263,7 +2257,7 @@ sub AT_ProgTimer {
                     my $qptitle = my_encode_qp($title);
                     $smtp->datasend("Subject: AUTOTIMER: New timer created for $qptitle\n");
                     $smtp->datasend("From: VDRAdmin-AM AutoTimer <$CONFIG{MAIL_FROM}>\n");
-                    $smtp->datasend("Auto-Submitted: auto-generated\n"); # RFC 3834
+                    $smtp->datasend("Auto-Submitted: auto-generated\n");  # RFC 3834
                     $smtp->datasend("MIME-Version: 1.0\n");
                     $smtp->datasend("Content-Type: text/plain; charset=iso-8859-1\n");
                     $smtp->datasend("Content-Transfer-Encoding: 8bit\n");
@@ -2307,20 +2301,19 @@ sub my_encode_qp {
     return $title;
 }
 
-sub PackStatus {    #TODO: unused
-                    # make a 32 bit signed int with high 16 Bit as event_id and low 16 Bit as
-                    # active value
+sub PackStatus {  # TODO: Unused
+    # Make a 32 bit signed int with high 16 Bit as event_id and low 16 Bit as active value
     my ($active, $event_id) = @_;
 
-    # we must generate a 32 bit signed int, due perl knows no overflow at 32 bit,
+    # We must generate a 32 bit signed int, due perl knows no overflow at 32 bit,
     # we have to do the overflow manually:
 
-    # is the 16th bit set? then the signed 32 bit int is negative!
+    # Is the 16th bit set? Then the signed 32 bit int is negative!
     if ($event_id & 0x8000) {
 
-        # strip the first bit (by & 0x7FFF) of the event_id, so a 15 bit
+        # Strip the first bit (by & 0x7FFF) of the event_id, so a 15 bit
         # (positive) int will remain, then shift the int 16 bits to the left and
-        # add active  -- result is a 31 bit (always positive) int.
+        # add active -- result is a 31 bit (always positive) int.
         # The 32nd bit is the minus sign, and due the (binary) smallest value
         # is the (int) lowest possible number, we have to subtract the lowest
         # value + 1 from the 31 bit value -- result is the signed 32 bit int equal
@@ -2331,17 +2324,17 @@ sub PackStatus {    #TODO: unused
     }
 }
 
-sub UnpackActive {    #TODO: unused
+sub UnpackActive {  # TODO: Unused
     my ($tmstatus) = @_;
 
-    # strip the first 16 bit
+    # Strip the first 16 bit
     return ($tmstatus & 0xFFFF);
 }
 
-sub UnpackEvent_id {    #TODO: unused
+sub UnpackEvent_id {  # TODO: Unused
     my ($tmstatus) = @_;
 
-    # remove the lower 16 bit by shifting the value 16 bits to the right
+    # Remove the lower 16 bit by shifting the value 16 bits to the right
     return $tmstatus >> 16;
 }
 
@@ -2353,15 +2346,15 @@ sub CheckTimers {
 
         next unless $timer->{autotimer};
 
-        # match by event_id
+        # Match by event_id
         if ($timer->{autotimer} == $AT_BY_EVENT_ID) {
             for $event (@{ $EPG{ $timer->{vdr_id} } }) {
 
-                # look for matching event_id on the same channel -- it's unique
+                # Look for matching event_id on the same channel -- it's unique
                 if ($timer->{event_id} == $event->[EV_EVENT_ID]) {
                     Log(LOG_DEBUG, sprintf("[AUTOTIMER] CheckTimers: Checking timer \"%s\" (No. %s) for changes by Event-ID", $timer->{title}, $timer->{id}));
 
-                    # update timer if the existing one differs from the EPG
+                    # Update timer if the existing one differs from the EPG
                     # (don't check for changed title, as this will break autotimers' "directory" setting)
                     if (   ($timer->{start} != ($event->[EV_START] - $timer->{bstart} * 60))
                         || ($timer->{stop} != ($event->[EV_STOP] + $timer->{bstop} * 60)))
@@ -2377,10 +2370,10 @@ sub CheckTimers {
                             $timer->{prio},
                             $timer->{lft},
 
-                            # don't update title as this may differ from what has been set by the user
+                            # Don't update title as this may differ from what has been set by the user
                             $timer->{title},
 
-                            # leave summary untouched.
+                            # Leave summary untouched.
                             $timer->{summary},
                         );
                     }
@@ -2388,7 +2381,7 @@ sub CheckTimers {
             }
         }
 
-        # match by channel number and start/stop time
+        # Match by channel number and start/stop time
         elsif ($timer->{autotimer} == $AT_BY_TIME) {
 
             # We're checking only timers which don't record
@@ -2398,14 +2391,14 @@ sub CheckTimers {
 
                 for my $event (@{ $EPG{ $timer->{vdr_id} } }) {
 
-                    # look for events within the margins of the current timer
+                    # Look for events within the margins of the current timer
                     if (($event->[EV_START] < $timer->{stop}) && ($event->[EV_STOP] > $timer->{start})) {
                         push @eventlist, $event;
                     }
                 }
 
-                # now we have all events in eventlist that touch the old timer margins
-                # check for each event how probable it is matching the old timer
+                # Now we have all events in eventlist that touch the old timer margins
+                # Check for each event how probable it is matching the old timer
                 if (scalar(@eventlist) > 0) {
                     my $origlen = ($timer->{stop} - $timer->{bstop} * 60) - ($timer->{start} + $timer->{bstart} * 60);
                     next unless($origlen);
@@ -2434,7 +2427,7 @@ sub CheckTimers {
                         }
                     }
 
-                    # update timer if the existing one differs from the EPG
+                    # Update timer if the existing one differs from the EPG
                     if (   ($timer->{start} > ($event->[EV_START] - $timer->{bstart} * 60))
                         || ($timer->{stop} < ($event->[EV_STOP] + $timer->{bstop} * 60)))
                     {
@@ -2449,10 +2442,10 @@ sub CheckTimers {
                             $timer->{prio},
                             $timer->{lft},
 
-                            # don't touch the title since we're not too sure about the event
+                            # Don't touch the title since we're not too sure about the event
                             $timer->{title},
 
-                            # leave summary untouched.
+                            # Leave summary untouched.
                             $timer->{summary},
                         );
                     }
@@ -2465,7 +2458,7 @@ sub CheckTimers {
 }
 
 #############################################################################
-# epgsearch
+# EPGSearch
 #############################################################################
 sub epgsearch_list {
     return if (UptoDate() != 0);
@@ -2567,25 +2560,25 @@ sub epgsearch_edit {
     my @sel_bl;
 
     if ($do_test) {
-        # test search
+        # Test search
         my $temp = epgsearch_Param2Line();
         $search = ExtractEpgSearchConf(($id ? $id : "0") . ":" . $temp);
         @sel_bl = $q->param("sel_blacklists");
         @matches = EpgSearchQuery("plug epgsearch qrys 0:" . $temp);
     } elsif (defined $id) {
-        # edit search
+        # Edit search
         my @temp = ParseEpgSearch($id);
         $search = pop @temp;
         @sel_bl = split(/\|/, $search->{sel_blacklists});
     } else {
-        # new search
+        # New search
         if (defined $template_id) {
             my @temp = GetEpgSearchTemplate($template_id);
             $search = pop @temp;
-            $search->{pattern} = "" unless ($edit_template); # don't want the template's name as search pattern
+            $search->{pattern} = "" unless ($edit_template);  # Don't want the template's name as search pattern
             @sel_bl = split(/\|/, $search->{sel_blacklists});
         } else {
-            #TODO: defaults for PRIO, LFT, BUFFER START/STOP
+            # TODO: Defaults for PRIO, LFT, BUFFER START/STOP
             $search->{use_title}    = 1;
             $search->{use_subtitle} = 1;
             $search->{use_descr}    = 1;
@@ -2787,8 +2780,8 @@ sub EpgSearchQuery {
         chomp;
         next if (length($_) == 0);
         last if(/^no results$/);
-#        Suchtimer-ID : Event-ID : Title : Subtitle : Event-Begin : Event-Ende :
-#        Kanalnummer : Timer-Start : Timer-Ende : Timer-File : hat/bekommt Timer
+#        Searchtimer-ID : Event-ID : Title : Subtitle : Event-Start : Event-End :
+#        Channelnumber : Timer-Start : Timer-End : Timer-File : Has/Becomes timer
         my ($es_id, $event_id, $title, $subtitle, $estart, $estop, $chan, $tstart, $tstop, $tdir, $has_timer) = split(/:/);
         if ($title) {
             $title =~ s/\|/:/g;
@@ -2823,79 +2816,78 @@ sub ExtractEpgSearchConf {
     my $line = shift;
 
     my $timer;
-        ($timer->{id},               # 1 - unique search timer id
-         $timer->{pattern},          # 2 - the search term
-         $timer->{use_time},         # 3 - use time? 0/1
-         $timer->{time_start},       # 4 - start time in HHMM
-         $timer->{time_stop},        # 5 - stop time in HHMM
-         $timer->{use_channel},      # 6 - use channel? 0 = no,  1 = Intervall, 2 = Channel group, 3 = FTA only
-         $timer->{channels},         # 7 - if 'use channel' = 1 then channel id[|channel id] in vdr format,
+        ($timer->{id},               # 1 - Unique search timer id
+         $timer->{pattern},          # 2 - The search term
+         $timer->{use_time},         # 3 - Use time? 0/1
+         $timer->{time_start},       # 4 - Start time in HHMM
+         $timer->{time_stop},        # 5 - Stop time in HHMM
+         $timer->{use_channel},      # 6 - Use channel? 0 = no,  1 = Intervall, 2 = Channel group, 3 = FTA only
+         $timer->{channels},         # 7 - If 'use channel' = 1 then channel id[|channel id] in vdr format,
                                      #     one entry or min/max entry separated with |, if 'use channel' = 2
                                      #     then the channel group name
-         $timer->{matchcase},        # 8 - match case? 0/1
-         $timer->{mode},             # 9 - search mode:
-                                     #      0 - the whole term must appear as substring
-                                     #      1 - all single terms (delimiters are blank,',', ';', '|' or '~')
+         $timer->{matchcase},        # 8 - Match case? 0/1
+         $timer->{mode},             # 9 - Search mode:
+                                     #      0 - The whole term must appear as substring
+                                     #      1 - All single terms (delimiters are blank,',', ';', '|' or '~')
                                      #          must exist as substrings.
-                                     #      2 - at least one term (delimiters are blank, ',', ';', '|' or '~')
+                                     #      2 - At least one term (delimiters are blank, ',', ';', '|' or '~')
                                      #          must exist as substring.
-                                     #      3 - matches exactly
-                                     #      4 - regular expression
-         $timer->{use_title},        #10 - use title? 0/1
-         $timer->{use_subtitle},     #11 - use subtitle? 0/1
-         $timer->{use_descr},        #12 - use description? 0/1
-         $timer->{use_duration},     #13 - use duration? 0/1
-         $timer->{min_duration},     #14 - min duration in minutes
-         $timer->{max_duration},     #15 - max duration in minutes
-         $timer->{has_action},       #16 - use as search timer? 0/1
-         $timer->{use_days},         #17 - use day of week? 0/1
-         $timer->{which_days},       #18 - day of week (0 = sunday, 1 = monday...)
-         $timer->{is_series},        #19 - use series recording? 0/1
-         $timer->{directory},        #20 - directory for recording
-         $timer->{prio},             #21 - priority of recording
-         $timer->{lft},              #22 - lifetime of recording
-         $timer->{bstart},           #23 - time margin for start in minutes
-         $timer->{bstop},            #24 - time margin for stop in minutes
-         $timer->{use_vps},          #25 - use VPS? 0/1
-         $timer->{action},           #26 - action:
-                                     #      0 = create a timer
-                                     #      1 = announce only via OSD (no timer)
-                                     #      2 = switch only (no timer)
-         $timer->{use_extepg},       #27 - use extended EPG info? 0/1  #TODO
-         $timer->{extepg_infos},     #28 - extended EPG info values. This entry has the following format #TODO
+                                     #      3 - Matches exactly
+                                     #      4 - Regular expression
+         $timer->{use_title},        #10 - Use title? 0/1
+         $timer->{use_subtitle},     #11 - Use subtitle? 0/1
+         $timer->{use_descr},        #12 - Use description? 0/1
+         $timer->{use_duration},     #13 - Use duration? 0/1
+         $timer->{min_duration},     #14 - Min duration in minutes
+         $timer->{max_duration},     #15 - Max duration in minutes
+         $timer->{has_action},       #16 - Use as search timer? 0/1
+         $timer->{use_days},         #17 - Use day of week? 0/1
+         $timer->{which_days},       #18 - Day of week (0 = sunday, 1 = monday...)
+         $timer->{is_series},        #19 - Use series recording? 0/1
+         $timer->{directory},        #20 - Directory for recording
+         $timer->{prio},             #21 - Priority of recording
+         $timer->{lft},              #22 - Lifetime of recording
+         $timer->{bstart},           #23 - Time margin for start in minutes
+         $timer->{bstop},            #24 - Time margin for stop in minutes
+         $timer->{use_vps},          #25 - Use VPS? 0/1
+         $timer->{action},           #26 - Action:
+                                     #      0 = Create a timer
+                                     #      1 = Announce only via OSD (no timer)
+                                     #      2 = Switch only (no timer)
+         $timer->{use_extepg},       #27 - Use extended EPG info? 0/1  # TODO
+         $timer->{extepg_infos},     #28 - Extended EPG info values. This entry has the following format # TODO
                                      #     (delimiter is '|' for each category, '#' separates id and value):
-                                     #     1 - the id of the extended EPG info category as specified in
+                                     #     1 - The id of the extended EPG info category as specified in
                                      #         epgsearchcats.conf
-                                     #     2 - the value of the extended EPG info category
+                                     #     2 - The value of the extended EPG info category
                                      #         (a ':' will be tranlated to "!^colon^!", e.g. in "16:9")
-         $timer->{avoid_repeats},    #29 - avoid repeats? 0/1
-         $timer->{allowed_repeats},  #30 - allowed repeats
-         $timer->{comp_title},       #31 - compare title when testing for a repeat? 0/1
-         $timer->{comp_subtitle},    #32 - compare subtitle when testing for a repeat? 0/1
-         $timer->{comp_descr},       #33 - compare description when testing for a repeat? 0/1
-         $timer->{comp_extepg_info}, #34 - compare extended EPG info when testing for a repeat? #TODO
+         $timer->{avoid_repeats},    #29 - Avoid repeats? 0/1
+         $timer->{allowed_repeats},  #30 - Allowed repeats
+         $timer->{comp_title},       #31 - Compare title when testing for a repeat? 0/1
+         $timer->{comp_descr},       #33 - Compare description when testing for a repeat? 0/1
+         $timer->{comp_extepg_info}, #34 - Compare extended EPG info when testing for a repeat? # TODO
                                      #     This entry is a bit field of the category ids.
-         $timer->{repeats_in_days},  #35 - accepts repeats only within x days
-         $timer->{delete_after},     #36 - delete a recording automatically after x days
-         $timer->{keep_recordings},  #37 - but keep this number of recordings anyway
-         $timer->{switch_before},    #38 - minutes before switch (if action = 2)
-         $timer->{pause},            #39 - pause if x recordings already exist
-         $timer->{use_blacklists},   #40 - blacklist usage mode (0 none, 1 selection, 2 all)
-         $timer->{sel_blacklists},   #41 - selected blacklist IDs separated with '|'
-         $timer->{fuzzy_tolerance},  #42 - fuzzy tolerance value for fuzzy searching
-         $timer->{use_for_fav},      #43 - use this search in favorites menu (0 no, 1 yes)
-         $timer->{results_menu},           #44 - menu to display results
-         $timer->{autodelete},             #45 - delMode ( 0 = no autodelete, 1 = after x recordings, 2 = after y days after 1. recording)
-         $timer->{del_after_recs},         #46 - delAfterCountRecs (x recordings)
-         $timer->{del_after_days},         #47 - delAfterDaysOfFirstRec (y days)
-         $timer->{searchtimer_from},       #48 - useAsSearchTimerFrom (if "use as search timer?" = 2)
-         $timer->{searchtimer_until},      #49 - useAsSearchTimerTil (if "use as search timer?" = 2)
-         $timer->{ignore_missing_epgcats}, #50 - ignoreMissingEPGCats
-         $timer->{unmute},                 #51 - unmute sound if off when used as switch timer
-         $timer->{min_match},              #52 - the minimum required match in percent when descriptions are compared to avoid repeats (-> 33)
+         $timer->{repeats_in_days},  #35 - Accepts repeats only within x days
+         $timer->{delete_after},     #36 - Delete a recording automatically after x days
+         $timer->{keep_recordings},  #37 - But keep this number of recordings anyway
+         $timer->{switch_before},    #38 - Minutes before switch (if action = 2)
+         $timer->{pause},            #39 - Pause if x recordings already exist
+         $timer->{use_blacklists},   #40 - Blacklist usage mode (0 none, 1 selection, 2 all)
+         $timer->{sel_blacklists},   #41 - Selected blacklist IDs separated with '|'
+         $timer->{fuzzy_tolerance},  #42 - Fuzzy tolerance value for fuzzy searching
+         $timer->{use_for_fav},      #43 - Use this search in favorites menu (0 no, 1 yes)
+         $timer->{results_menu},           #44 - Menu to display results
+         $timer->{autodelete},             #45 - DelMode ( 0 = no autodelete, 1 = after x recordings, 2 = after y days after 1. recording)
+         $timer->{del_after_recs},         #46 - DelAfterCountRecs (x recordings)
+         $timer->{del_after_days},         #47 - DelAfterDaysOfFirstRec (y days)
+         $timer->{searchtimer_from},       #48 - UseAsSearchTimerFrom (if "use as search timer?" = 2)
+         $timer->{searchtimer_until},      #49 - UseAsSearchTimerTil (if "use as search timer?" = 2)
+         $timer->{ignore_missing_epgcats}, #50 - IgnoreMissingEPGCats
+         $timer->{unmute},                 #51 - Unmute sound if off when used as switch timer
+         $timer->{min_match},              #52 - The minimum required match in percent when descriptions are compared to avoid repeats (-> 33)
          $timer->{unused}) = split(/:/, $line);
 
-        #format selected fields
+        # Format selected fields
         $timer->{time_start} =~ s/(\d\d)(\d\d)/$1:$2/ if($timer->{time_start});
         $timer->{time_stop} =~ s/(\d\d)(\d\d)/$1:$2/ if($timer->{time_stop});
         $timer->{min_duration} =~ s/(\d\d)(\d\d)/$1:$2/ if($timer->{min_duration});
@@ -2924,7 +2916,7 @@ sub ExtractEpgSearchConf {
             $timer->{channel_to} = $timer->{channel_from} unless ($timer->{channel_to});
             $timer->{channel_from_name} = get_name_from_uniqid($timer->{channel_from});
             $timer->{channel_to_name} = get_name_from_uniqid($timer->{channel_to});
-            #TODO: links to channels
+            # TODO: Links to channels
         }
 
         if ($timer->{use_days}) {
@@ -2972,7 +2964,7 @@ sub validTime {
     return unless ($t);
     my ($h, $m) = split(/:/, $t);
     $h = "0" . $h if (length($h) == 1);
-    if (length($h) > 2) {  #TODO: $m defined?
+    if (length($h) > 2) {  # TODO: $m defined?
         $m = substr($h, -2);
         $h = substr($h, 0, -2);
     }
@@ -3055,7 +3047,7 @@ sub epgsearch_Param2Line {
         $directory =~ s/:/\|/g;
     }
 
-    #TODO: $searchtimer_from & $searchtimer_until auf korrektes Format pr�fen
+    # TODO: Check $searchtimer_from & $searchtimer_until for validity
     my $searchtimer_from = $q->param("searchtimer_from");
     if ($searchtimer_from) {
         $searchtimer_from = my_mktime("0", "0", substr($searchtimer_from, 8, 2), substr($searchtimer_from, 5, 2) - 1, substr($searchtimer_from, 0, 4));
@@ -3124,7 +3116,7 @@ sub epgsearch_Param2Line {
                . ($q->param("comp_title") ? "1" : "0") . ":"
                . ($q->param("comp_subtitle") ? "1" : "0") . ":"
                . ($q->param("comp_descr") ? "1" : "0") . ":"
-               . ($q->param("comp_extepg_info") ? "1" : "0") . ":"    #TODO
+               . ($q->param("comp_extepg_info") ? "1" : "0") . ":"  # TODO
                . $q->param("repeats_in_days") . ":"
                . $q->param("delete_after") . ":"
                . $q->param("keep_recordings") . ":"
@@ -3149,7 +3141,7 @@ sub epgsearch_Param2Line {
     }
 
     $cmd .= ":" . $q->param("unused") if ($q->param("unused"));
-#print("CMD: $cmd\n");
+    #print("CMD: $cmd\n");
     return $cmd;
 }
 
@@ -3242,11 +3234,11 @@ sub epgsearch_bl_edit {
     my @ch_groups;
 
     if (defined $id) {
-        # edit blacklist
+        # Edit blacklist
         my @temp = ParseEpgSearchBlacklists($id);
         $blacklist = pop @temp;
     } else {
-        # new blacklist
+        # New blacklist
         $blacklist->{use_title}    = 1;
         $blacklist->{use_subtitle} = 1;
         $blacklist->{use_descr}    = 1;
@@ -3308,44 +3300,44 @@ sub ExtractEpgSearchBlacklistConf {
     my $line = shift;
 
     my $timer;
-        ($timer->{id},               # 1 - unique search timer id
-         $timer->{pattern},          # 2 - the search term
-         $timer->{use_time},         # 3 - use time? 0/1
-         $timer->{time_start},       # 4 - start time in HHMM
-         $timer->{time_stop},        # 5 - stop time in HHMM
-         $timer->{use_channel},      # 6 - use channel? 0 = no,  1 = Intervall, 2 = Channel group, 3 = FTA only
-         $timer->{channels},         # 7 - if 'use channel' = 1 then channel id[|channel id] in vdr format,
+        ($timer->{id},               # 1 - Unique search timer id
+         $timer->{pattern},          # 2 - The search term
+         $timer->{use_time},         # 3 - Use time? 0/1
+         $timer->{time_start},       # 4 - Start time in HHMM
+         $timer->{time_stop},        # 5 - Stop time in HHMM
+         $timer->{use_channel},      # 6 - Use channel? 0 = no,  1 = Intervall, 2 = Channel group, 3 = FTA only
+         $timer->{channels},         # 7 - If 'use channel' = 1 then channel id[|channel id] in vdr format,
                                      #     one entry or min/max entry separated with |, if 'use channel' = 2
                                      #     then the channel group name
-         $timer->{matchcase},        # 8 - match case? 0/1
-         $timer->{mode},             # 9 - search mode:
-                                     #      0 - the whole term must appear as substring
-                                     #      1 - all single terms (delimiters are blank,',', ';', '|' or '~')
+         $timer->{matchcase},        # 8 - Match case? 0/1
+         $timer->{mode},             # 9 - Search mode:
+                                     #      0 - The whole term must appear as substring
+                                     #      1 - All single terms (delimiters are blank,',', ';', '|' or '~')
                                      #          must exist as substrings.
-                                     #      2 - at least one term (delimiters are blank, ',', ';', '|' or '~')
+                                     #      2 - At least one term (delimiters are blank, ',', ';', '|' or '~')
                                      #          must exist as substring.
-                                     #      3 - matches exactly
-                                     #      4 - regular expression
-         $timer->{use_title},        #10 - use title? 0/1
-         $timer->{use_subtitle},     #11 - use subtitle? 0/1
-         $timer->{use_descr},        #12 - use description? 0/1
-         $timer->{use_duration},     #13 - use duration? 0/1
-         $timer->{min_duration},     #14 - min duration in minutes
-         $timer->{max_duration},     #15 - max duration in minutes
-         $timer->{use_days},         #16 - use day of week? 0/1
-         $timer->{which_days},       #17 - day of week (0 = sunday, 1 = monday...)
-         $timer->{use_extepg},       #18 - use extended EPG info? 0/1  #TODO
-         $timer->{extepg_infos},     #19 - extended EPG info values. This entry has the following format #TODO
+                                     #      3 - Matches exactly
+                                     #      4 - Regular expression
+         $timer->{use_title},        #10 - Use title? 0/1
+         $timer->{use_subtitle},     #11 - Use subtitle? 0/1
+         $timer->{use_descr},        #12 - Use description? 0/1
+         $timer->{use_duration},     #13 - Use duration? 0/1
+         $timer->{min_duration},     #14 - Min duration in minutes
+         $timer->{max_duration},     #15 - Max duration in minutes
+         $timer->{use_days},         #16 - Use day of week? 0/1
+         $timer->{which_days},       #17 - Day of week (0 = sunday, 1 = monday...)
+         $timer->{use_extepg},       #18 - Use extended EPG info? 0/1  # TODO
+         $timer->{extepg_infos},     #19 - Extended EPG info values. This entry has the following format  # TODO
                                      #     (delimiter is '|' for each category, '#' separates id and value):
-                                     #     1 - the id of the extended EPG info category as specified in
+                                     #     1 - The id of the extended EPG info category as specified in
                                      #         epgsearchcats.conf
-                                     #     2 - the value of the extended EPG info category
+                                     #     2 - The value of the extended EPG info category
                                      #         (a ':' will be tranlated to "!^colon^!", e.g. in "16:9")
-         $timer->{fuzzy_tolerance},  #20 - fuzzy tolerance value for fuzzy searching
-         $timer->{ignore_missing_epgcats}, #21 - ignoreMissingEPGCats
+         $timer->{fuzzy_tolerance},  #20 - Fuzzy tolerance value for fuzzy searching
+         $timer->{ignore_missing_epgcats}, #21 - IgnoreMissingEPGCats
          $timer->{unused}) = split(/:/, $line);
 
-        #format selected fields
+        # Format selected fields
         $timer->{time_start} =~ s/(\d\d)(\d\d)/$1:$2/ if($timer->{time_start});
         $timer->{time_stop} =~ s/(\d\d)(\d\d)/$1:$2/ if($timer->{time_stop});
         $timer->{min_duration} =~ s/(\d\d)(\d\d)/$1:$2/ if($timer->{min_duration});
@@ -3356,7 +3348,7 @@ sub ExtractEpgSearchBlacklistConf {
             $timer->{channel_to} = $timer->{channel_from} unless ($timer->{channel_to});
             $timer->{channel_from_name} = get_name_from_uniqid($timer->{channel_from});
             $timer->{channel_to_name} = get_name_from_uniqid($timer->{channel_to});
-            #TODO: links to channels
+            # TODO: Links to channels
         }
 
         if ($timer->{use_days}) {
@@ -3389,7 +3381,7 @@ sub ExtractEpgSearchBlacklistConf {
 }
 
 #############################################################################
-# regulary timers
+# Regulary timers
 #############################################################################
 sub my_mktime {
     my $sec  = 0;
@@ -3404,7 +3396,7 @@ sub my_mktime {
 }
 
 sub ParseTimer {
-    my $pc    = shift;    #TODO: what's this supposed to do?
+    my $pc    = shift;    # TODO: What's this supposed to do?
     my $tid   = shift;
     my $entry = 1;
 
@@ -3425,7 +3417,7 @@ sub ParseTimer {
         $recording = 1 if (($active & 8) == 8);
         $active    = 1 if ($active == 3 || $active == 9);
 
-        #$active = 1 if(($active & 1) == 1); #TODO
+        #$active = 1 if(($active & 1) == 1);  # TODO
 
         # replace "|" by ":" in timer's title (man vdr.5)
         $title =~ s/\|/\:/g;
@@ -3433,11 +3425,11 @@ sub ParseTimer {
         $title_js =~ s/\'/\\\'/g;
         $title_js =~ s/\"/&quot;/g;
 
-        if (length($dor) == 7) {    # repeating timer
+        if (length($dor) == 7) {  # Repeating timer
             $startsse = my_mktime(substr($start, 2, 2), substr($start, 0, 2), my_strftime("%d"), (my_strftime("%m") - 1), my_strftime("%Y"));
             $stopsse  = my_mktime(substr($stop,  2, 2), substr($stop,  0, 2), my_strftime("%d"), (my_strftime("%m") - 1), my_strftime("%Y"));
             if ($stopsse < $startsse) {
-                $stopsse += 86400;    # +1day
+                $stopsse += 86400;  # +1 day
             }
             $weekday = ((localtime(time))[6] + 6) % 7;
             $perrec = join("", substr($dor, $weekday), substr($dor, 0, $weekday));
@@ -3453,22 +3445,22 @@ sub ParseTimer {
             }
             $startsse += $off;
             $stopsse  += $off;
-        } elsif (length($dor) == 18) {    # first-day timer
+        } elsif (length($dor) == 18) {  # First-day timer
             $dor =~ /.{7}\@(\d\d\d\d)-(\d\d)-(\d\d)/;
             $startsse = my_mktime(substr($start, 2, 2), substr($start, 0, 2), $3, ($2 - 1), $1);
 
             # 31 + 1 = ??
             $stopsse = my_mktime(substr($stop, 2, 2), substr($stop, 0, 2), $stop > $start ? $3 : $3 + 1, ($2 - 1), $1);
-        } else {                          # regular timer
-            if ($dor =~ /(\d\d\d\d)-(\d\d)-(\d\d)/) {    # vdr >= 1.3.23
+        } else {  # Regular timer
+            if ($dor =~ /(\d\d\d\d)-(\d\d)-(\d\d)/) {  # vdr >= 1.3.23
                 $startsse = my_mktime(substr($start, 2, 2), substr($start, 0, 2), $3, ($2 - 1), $1);
                 $stopsse = my_mktime(substr($stop, 2, 2), substr($stop, 0, 2), $stop > $start ? $3 : $3 + 1, ($2 - 1), $1);
-            } else {                                     # vdr < 1.3.23
+            } else {  # vdr < 1.3.23
                 next unless($start || $stop);
                 $startsse = my_mktime(substr($start, 2, 2), substr($start, 0, 2), $dor, (my_strftime("%m") - 1), my_strftime("%Y"));
                 $stopsse = my_mktime(substr($stop, 2, 2), substr($stop, 0, 2), $stop > $start ? $dor : $dor + 1, (my_strftime("%m") - 1), my_strftime("%Y"));
 
-                # move timers which have expired one month into the future
+                # Move timers which have expired one month into the future
                 if (length($dor) != 7 && $stopsse < time) {
                     $startsse = my_mktime(substr($start, 2, 2), substr($start, 0, 2), $dor, (my_strftime("%m") % 12), (my_strftime("%Y") + (my_strftime("%m") == 12 ? 1 : 0)));
                     $stopsse = my_mktime(substr($stop, 2, 2), substr($stop, 0, 2), $stop > $start ? $dor : $dor + 1, (my_strftime("%m") % 12), (my_strftime("%Y") + (my_strftime("%m") == 12 ? 1 : 0)));
@@ -3476,8 +3468,8 @@ sub ParseTimer {
             }
         }
 
-        if ($CONFIG{RECORDINGS} && length($dor) == 7) {    # repeating timer
-                                                           # generate repeating timer entries for up to 28 days
+        if ($CONFIG{RECORDINGS} && length($dor) == 7) {  # Repeating timer
+                                                         # Generate repeating timer entries for up to 28 days
             $first = 1;
             for ($weekday += $off / 86400, $off = 0 ; $off < 28 ; $off++) {
                 $perrec = join("", substr($dor, ($weekday + $off) % 7), substr($dor, 0, ($weekday + $off) % 7));
@@ -3493,7 +3485,7 @@ sub ParseTimer {
                       startsse    => $startsse + $off * 86400,
                       stopsse     => $stopsse + $off * 86400,
                       active      => $active,
-                      recording   => $first ? $recording : 0,                                         # only the first might record
+                      recording   => $first ? $recording : 0,  # Only the first might record
                       event_id    => $event_id,
                       cdesc       => get_name_from_vdrid($vdr_id),
                       transponder => get_transponder_from_vdrid($vdr_id),
@@ -3550,7 +3542,7 @@ sub ParseTimer {
             );
         }
 
-        # save index of entry with specific timer id for later use
+        # Save index of entry with specific timer id for later use
         if ($tid && $tid == $id) {
             $entry = $length;
         }
@@ -3563,7 +3555,7 @@ sub ParseTimer {
     }
 }
 
-# extract our own metadata from a timer's aux field.
+# Extract our own metadata from a timer's aux field.
 sub extract_timer_metadata {
     my $aux = shift;
     return unless defined $aux;
@@ -3572,7 +3564,7 @@ sub extract_timer_metadata {
         return;
     }
 
-    if (defined $1) { # VDRAdmin-AM AutoTimer
+    if (defined $1) {  # VDRAdmin-AM AutoTimer
         $aux = $1;
         my $epg_id    = ($aux =~ /<epgid>(.*)<\/epgid>/i) ? $1 : undef;
         my $autotimer = ($aux =~ /<autotimer>(.*)<\/autotimer>/i) ? $1 : undef;
@@ -3580,7 +3572,7 @@ sub extract_timer_metadata {
         my $bstop     = ($aux =~ /<bstop>(.*)<\/bstop>/i) ? $1 : undef;
         my $pattern   = ($aux =~ /<pattern>(.*)<\/pattern>/i) ? $1 : undef;
         return ($autotimer, $epg_id, $bstart, $bstop, $pattern, $TOOL_AUTOTIMER);
-    } elsif (defined $2) { # EPGSearch
+    } elsif (defined $2) {  # EPGSearch
         $aux = $2;
         #* Fields differ in newer EPGSearch. Sample from EPGSearch 2.4.4:
         #<epgsearch>
@@ -3597,14 +3589,14 @@ sub extract_timer_metadata {
             my $bstart  = ($aux =~ /<start>(.*)<\/start>/i) ? $1 : undef;
             my $bstop   = ($aux =~ /<stop>(.*)<\/stop>/i) ? $1 : undef;
             return (undef, $epg_id, $bstart, $bstop, $pattern, $TOOL_EPGSEARCH);
-        } else { # EPGSearch old version
+        } else {  # EPGSearch old version
             my $epg_id    = ($aux =~ /<eventid>(.*)<\/eventid>/i) ? $1 : undef;
             my $autotimer = ($aux =~ /<update>(.*)<\/update>/i) ? $1 : undef;
             my $bstart    = ($aux =~ /<bstart>(.*)<\/bstart>/i) ? $1 : undef;
             my $bstop     = ($aux =~ /<bstop>(.*)<\/bstop>/i) ? $1 : undef;
             return ($autotimer, $epg_id, $bstart, $bstop, undef, $TOOL_EPGSEARCH);
         }
-    } elsif (defined $3) { # TVScraper
+    } elsif (defined $3) {  # TVScraper
         # Fields are <causedBy> and <reason>
         # causedBy: Path to the recording that caused this timer to be created
         # reason:
@@ -3616,18 +3608,18 @@ sub extract_timer_metadata {
         return (undef, undef, undef, undef, $pattern, $TOOL_TVSCRAPER);
     }
 
-    return; # In case none of the conditions are met
+    return;  # In case none of the conditions are met
 }
 
 sub append_timer_metadata {
     my ($aux, $epg_id, $autotimer, $bstart, $bstop, $pattern, $tool) = @_;
 
     if ($tool == $TOOL_AUTOTIMER) {
-        # remove old autotimer info
+        # Remove old autotimer info
         $aux =~ s/\|?<vdradmin-am>.*<\/vdradmin-am>//i if ($aux);
         $aux = substr($aux, 0, 9000) if ($FEATURES{VDRVERSION} < 10336 and length($aux) > 9000);
 
-        # add a new line if VDR<1.3.44 because then there might be a summary
+        # Add a new line if VDR<1.3.44 because then there might be a summary
         $aux .= "|" if ($FEATURES{VDRVERSION} < 10344 and length($aux));
         $aux .= "<vdradmin-am>";
         $aux .= "<epgid>$epg_id</epgid>" if ($epg_id);
@@ -3637,11 +3629,11 @@ sub append_timer_metadata {
         $aux .= "<pattern>$pattern</pattern>" if ($pattern);
         $aux .= "</vdradmin-am>";
     } elsif ($tool == $TOOL_EPGSEARCH) {
-        # remove old epgsearch info
+        # Remove old epgsearch info
         $aux =~ s/\|?<epgsearch>.*<\/epgsearch>//i if ($aux);
         $aux = substr($aux, 0, 9000) if ($FEATURES{VDRVERSION} < 10336 and length($aux) > 9000);
 
-        # add a new line if VDR<1.3.44 because then there might be a summary
+        # Add a new line if VDR<1.3.44 because then there might be a summary
         $aux .= "|" if ($FEATURES{VDRVERSION} < 10344 and length($aux));
         $aux .= "<epgsearch>";
         $aux .= "<eventid>$epg_id</eventid>" if ($epg_id);
@@ -3699,7 +3691,7 @@ sub ProgTimer {
     # $start and $stop are expected as seconds since 00:00:00 1970-01-01 UTC.
     my ($timer_id, $active, $event_id, $channel, $start, $stop, $prio, $lft, $title, $summary, $dor) = @_;
 
-    $title =~ s/\:/|/g;    # replace ":" by "|" in timer's title (man vdr.5)
+    $title =~ s/\:/|/g;  # Replace ":" by "|" in timer's title (man vdr.5)
 
     my $send_cmd = $timer_id ? "modt $timer_id" : "newt";
     my $send_dor = $dor ? $dor : RemoveLeadingZero(strftime("%d", localtime($start)));
@@ -3719,7 +3711,7 @@ sub RedirectToReferer {
     }
 }
 
-sub salt {    #TODO: unused
+sub salt {  # TODO: Unused
     $_ = $_[0];
     my $string;
     my ($offset1, $offset2);
@@ -3861,7 +3853,7 @@ sub my_strftime {
     return (strftime($format, $time ? localtime($time) : localtime(time)));
 }
 
-sub GetFirstChannel {    #TODO: unused
+sub GetFirstChannel {  # TODO: Unused
     return ($CHAN{$CHAN_FULL}->{channels}[0]->{service_id});
 }
 
@@ -3886,13 +3878,13 @@ sub Decode_Referer {
     return ($ref);
 }
 
-sub encode_ref {    #TODO: unused
+sub encode_ref {  # TODO: Unused
     my ($tmp) = $_[0]->url(-relative => 1, -query => 1);
     my (undef, $query) = split(/\?/, $tmp, 2);
     return (MIME::Base64::encode_base64($query, ""));
 }
 
-sub decode_ref {    #TODO: unused
+sub decode_ref {  # TODO: Unused
     return (MIME::Base64::decode_base64($_[0]));
 }
 
@@ -3955,22 +3947,22 @@ sub ReadConfig {
 
         ValidConfig();
 
-        #Migrate settings
-        #v3.4.5
+        # Migrate settings
+        # v3.4.5
         $CONFIG{MAIL_FROM} = "autotimer@" . $CONFIG{MAIL_FROMDOMAIN} if ($CONFIG{MAIL_FROM} =~ /from\@address.tld/);
-        #v3.4.6beta
+        # v3.4.6beta
         $CONFIG{SKIN} = "default" if(($CONFIG{SKIN} eq "bilder") || ($CONFIG{SKIN} eq "copper") || ($CONFIG{SKIN} eq "default.png"));
-        #v3.5.3
+        # v3.5.3
         delete $CONFIG{EPG_DIRECT};
         delete $CONFIG{EPG_FILENAME};
-        #v3.5.4rc
+        # v3.5.4rc
         if (defined $CONFIG{AT_TIMEOUT}) {
             $CONFIG{CACHE_TIMEOUT} = $CONFIG{AT_TIMEOUT} if ($CONFIG{AT_TIMEOUT} < $CONFIG{CACHE_TIMEOUT});
             delete $CONFIG{AT_TIMEOUT};
         }
-        #v3.6.2
+        # v3.6.2
         delete $CONFIG{VDRVFAT};
-        #v3.6.5
+        # v3.6.5
         $CONFIG{LOGLEVEL} = 4 if ($CONFIG{LOGLEVEL} == 81);
 
     } else {
@@ -4072,7 +4064,7 @@ sub VideoDiskFree {
 }
 
 #############################################################################
-# frontend
+# Frontend
 #############################################################################
 sub show_index {
     return if (UptoDate() != 0);
@@ -4129,7 +4121,7 @@ sub prog_detail {
                 $video        = getEventVideo($event);
                 $audio        = getEventAudio($event);
 
-                # find epgimages
+                # Find epgimages
                 if ($CONFIG{EPGIMAGES} && -d $CONFIG{EPGIMAGES}) {
                     my $uniq_id = GetChannelUniqIdByNumber($vdr_id);
                     for my $epgimage (<$CONFIG{EPGIMAGES}/${uniq_id}_${epg_id}\[\._\]*>) {
@@ -4221,7 +4213,7 @@ sub prog_detail {
 
 sub prog_detail_form {
 
-    # determine referer (redirect to where we come from)
+    # Determine referer (Redirect to where we come from)
     my $ref = getReferer();
 
     my $vdr_id = $q->param("vdr_id");
@@ -4271,7 +4263,7 @@ sub prog_detail_aktion {
         my $subtitle    = CGI::unescapeHTML(scalar $q->param("subtitle"));
         my $description = CGI::unescapeHTML(scalar $q->param("description"));
         my $vps         = $q->param("vps");
-        my $table_id    = 0;    # must be zero for external epg data
+        my $table_id    = 0;  # Must be zero for external epg data
 
         my ($new_subtitle, $new_description, $new_video, $new_audio, $new_vps) = ("","","","","");
         my $event = EPG_getEntry($vdr_id, $event_id);
@@ -4319,7 +4311,7 @@ sub prog_detail_aktion {
                 #printf "something went wrong during EPG update: %s\n", $result;
                 main::HTMLError(sprintf($ERROR_MESSAGE{send_command}, $CONFIG{VDR_HOST}));
             } else {
-                # don't reread complete epg, just change the cache
+                # Don't reread complete epg, just change the cache
                 $event->[EV_TITLE] = $title;
                 $event->[EV_SUBTITLE] = $subtitle;
                 $event->[EV_SUMMARY] = $description;
@@ -4335,7 +4327,7 @@ sub prog_detail_aktion {
     }
 }
 #############################################################################
-# program listing
+# Program listing
 #############################################################################
 sub prog_list {
     return if (UptoDate() != 0);
@@ -4354,9 +4346,9 @@ sub prog_list {
     my (@channel, $current);
     for my $channel (@{$CHAN{$CONFIG{CHANNELS_WANTED_PRG}}->{channels}}) {
 
-        # skip channels without EPG data
+        # Skip channels without EPG data
         if ($CONFIG{CHANNELS_WITHOUT_EPG} || ChannelHasEPG($channel->{vdr_id})) {
-            # called without vdr_id, redirect to the first available channel
+            # Called without vdr_id, redirect to the first available channel
             $vdr_id = $channel->{vdr_id} if(!$vdr_id);
             $current = 1 if ($vdr_id == $channel->{vdr_id});
             push(@channel,
@@ -4382,7 +4374,7 @@ sub prog_list {
         }
     }
 
-    # find the next/prev channel
+    # Find the next/prev channel
     my $ci = 0;
     for (my $i = 0 ; $i <= $#channel ; $i++) {
         ($ci = $i) if ($vdr_id == $channel[$i]->{vdr_id});
@@ -4403,7 +4395,7 @@ sub prog_list {
     for my $event (@{ $EPG{$vdr_id} }) {
         if (my_strftime("%d", $event->[EV_START]) != $day) {
 
-            # new day
+            # New day
             push(@show,
                  {  endd => 1,
                     next_channel => $next_channel ? "$MyURL?aktion=prog_list&amp;vdr_id=$next_channel" : undef,
@@ -4502,7 +4494,7 @@ sub prog_list {
 }
 
 #############################################################################
-# program listing 2
+# Program listing 2
 # "What's up today" extension.
 #
 # Contributed by Thomas Blon, 6. Mar 2004
@@ -4527,7 +4519,7 @@ sub prog_list2 {
 
     for my $channel (@{$CHAN{$CONFIG{CHANNELS_WANTED_PRG2}}->{channels}}) {
 
-        # skip channels without EPG data
+        # Skip channels without EPG data
         if ($CONFIG{CHANNELS_WITHOUT_EPG} || ChannelHasEPG($channel->{vdr_id})) {
             push(@channel,
                  {  name   => $channel->{name},
@@ -4543,10 +4535,10 @@ sub prog_list2 {
     my $border;
     $border = timelocal(0, $minute, $hour, substr($day, 6, 2), substr($day, 4, 2) - 1, substr($day, 0, 4)) if($day);
     my $time = getStartTime($param_time ? $param_time : undef, undef, $border);
-    foreach (@channel) {    # loop through all channels
+    foreach (@channel) {  # Loop through all channels
         $vdr_id = $_->{vdr_id};
 
-        # find the next/prev channel
+        # Find the next/prev channel
         my $ci = 0;
         for (my $i = 0 ; $i <= $#channel ; $i++) {
             ($ci = $i) if ($vdr_id == $channel[$i]->{vdr_id});
@@ -4662,7 +4654,7 @@ sub prog_list2 {
             );
             push(@show, { endd => 1 });
         }
-    }    # end: for $vdr_id
+    }  # End: for $vdr_id
 
     my @days;
     foreach (keys %hash_days) {
@@ -4695,7 +4687,6 @@ sub prog_list2 {
         }
     }
 
-    #
     my $vars = {
         title => $day == $current_day ? gettext("Playing Today") : ($day == $current_day + 1 ? gettext("Playing Tomorrow") : sprintf(gettext("Playing on the %s"), $hash_days{$day})),
         now            => my_strftime("%H:%M", $time),
@@ -4718,7 +4709,7 @@ sub prog_list2 {
 }
 
 #############################################################################
-# regular timers
+# Regular timers
 #############################################################################
 sub timer_list {
     return if (UptoDate() != 0);
@@ -4744,8 +4735,8 @@ sub timer_list {
 
         $timer->{delurl}    = $MyURL . "?aktion=timer_delete&amp;timer_id=" . $timer->{id},
         $timer->{modurl}    = $MyURL . "?aktion=timer_new_form&amp;timer_id=" . $timer->{id},
-        $timer->{toggleurl} = sprintf("%s?aktion=timer_toggle&amp;active=%s&amp;id=%s", $MyURL, ($timer->{active} & 1) ? 0 : 1, $timer->{id}), #TODO: nur id?
-        $timer->{dor}       = my_strftime("%a %d.%m", $timer->{startsse});    #TODO: localize date
+        $timer->{toggleurl} = sprintf("%s?aktion=timer_toggle&amp;active=%s&amp;id=%s", $MyURL, ($timer->{active} & 1) ? 0 : 1, $timer->{id}),  # TODO: nur id?
+        $timer->{dor}       = my_strftime("%a %d.%m", $timer->{startsse});  # TODO: localize date
 
         $timer->{title} = CGI::escapeHTML($timer->{title});
         $TagAnfang      = my_mktime(0, 0, my_strftime("%d", $timer->{start}), my_strftime("%m", $timer->{start}), my_strftime("%Y", $timer->{start}));
@@ -4782,7 +4773,7 @@ sub timer_list {
                 $last = $ii;
             }
 
-            # Liste der benutzten Transponder
+            # List of used transponders
             my @Transponder = $timer[$ii]->{transponder};
             $timer[$ii]->{collision} = 0;
 
@@ -4792,9 +4783,9 @@ sub timer_list {
                 {
                     if ($timer[$ii]->{active} && $timer[$jj]->{active}) {
 
-                        # Timer kollidieren zeitlich. Pruefen, ob die Timer evtl. auf
-                        # gleichem Transponder oder CAM liegen und daher ohne Probleme
-                        # aufgenommen werden koennen
+    # Timers collide in time. Check if the timers are possibly on
+    # the same transponder or CAM and therefore can be recorded
+    # without problems
                         Log(LOG_DEBUG, sprintf("[TIMER] Collision: %s (%s, %s) -- %s (%s, %s)\n", substr($timer[$ii]->{title}, 0, 15), $timer[$ii]->{vdr_id}, $timer[$ii]->{transponder}, $timer[$ii]->{ca}, substr($timer[$jj]->{title}, 0, 15), $timer[$jj]->{vdr_id}, $timer[$jj]->{transponder}, $timer[$jj]->{ca}));
 
                         if (   $timer[$ii]->{vdr_id} != $timer[$jj]->{vdr_id}
@@ -4802,18 +4793,17 @@ sub timer_list {
                             && $timer[$ii]->{ca} >= 100)
                         {
 
-                            # Beide Timer laufen auf dem gleichen CAM auf verschiedenen
-                            # Kanaelen, davon kann nur einer aufgenommen werden
+    # Both timers run on the same CAM on different channels, only one of them can be recorded
                             Log(LOG_DEBUG, "[TIMER] Both channels use same CAM");
                             #($timer[$ii]->{collision}) = $CONFIG{RECORDINGS}; #OLDIMPL
                             ($timer[$ii]->{collision})++; #NEWIMPL
 
-                            # Nur Kosmetik: Transponderliste vervollstaendigen
+    # Just cosmetics: Complete the transponder list
                             push(@Transponder, $timer[$jj]->{transponder});
                         } else {
 
-                            # "grep" prueft die Bedingung fuer jedes Element, daher den
-                            # Transponder vorher zwischenspeichern -- ist effizienter
+                            # "grep" checks the condition for each element, so store the
+                            # transponder beforehand -- it's more efficient
                             my $t = $timer[$jj]->{transponder};
                             if (scalar(grep($_ eq $t, @Transponder)) == 0) {
                                 ($timer[$ii]->{collision})++;
@@ -4850,7 +4840,6 @@ sub timer_list {
         }
     }
 
-    #
     my ($ii, $jj, $kk, $current, $title);
 
     for ($ii = 0 ; $ii < @timer ; $ii++) {
@@ -5039,7 +5028,7 @@ sub timer_new_form {
     }
 
     my $this_event;
-    if ($epg_id) {    # new timer
+    if ($epg_id) {  # New timer
         my $this = EPG_getEntry($vdr_id, $epg_id);
         $this_event->{active}   = 1;
         $this_event->{event_id} = $this->[EV_EVENT_ID];
@@ -5061,14 +5050,14 @@ sub timer_new_form {
             $this_event->{autotimer} = $this_event->{at_epg} ? $AT_BY_EVENT_ID : $AT_BY_TIME;
         }
 
-    } elsif ($timer_id) {    # edit existing timer
+    } elsif ($timer_id) {  # Edit existing timer
         $this_event = ParseTimer(0, $timer_id);
         if (($this_event->{tool} == $TOOL_EPGSEARCH) && $this_event->{pattern}) {
             $this_event->{hide_at_check} = 1;
         }
         $this_event->{at_epg}    = $this_event->{event_id} ? 1 : 0;
         $this_event->{autotimer} = 0 unless($this_event->{autotimer});
-    } else {                 # none of the above
+    } else {  # None of the above
         $this_event->{start}  = time();
         $this_event->{stop}   = 0;
         $this_event->{active} = 1;
@@ -5081,7 +5070,7 @@ sub timer_new_form {
         push(@channels, $channel);
     }
 
-    # determine referer (redirect to where we come from)
+    # Determine referer (Redirect to where we come from)
     my $ref = getReferer();
 
     my $displaysummary = $this_event->{summary};
@@ -5172,7 +5161,7 @@ sub timer_add {
         if (length($q->param("summary")) > 0) {
             $data->{summary} = $q->param("summary");
 
-            #$data->{summary} =~ s/\://g;    # summary may have colons (man vdr.5)
+            #$data->{summary} =~ s/\://g; # Summary may have colons (man vdr.5)
             $data->{summary} =~ s/\r//g;
             $data->{summary} =~ s/\n/|/g;
         }
@@ -5180,7 +5169,7 @@ sub timer_add {
         my $dor = $data->{dor};
         if (length($data->{dor}) == 7 || length($data->{dor}) == 10 || length($data->{dor}) == 18) {
 
-            # dummy
+            # Dummy
             $dor = 1;
         }
         $data->{startsse} = my_mktime(substr($data->{start}, 2, 2), substr($data->{start}, 0, 2), $dor, (my_strftime("%m") - 1), my_strftime("%Y"));
@@ -5295,7 +5284,7 @@ sub rec_stream {
         }
         last if ($id == $i);
     }
-    $time = substr($time, 0, 5);    # needed for wareagel-patch
+    $time = substr($time, 0, 5);  # Needed for wareagel-patch
     if ($id == $i) {
         my @urls = ();
         $title =~ s/[ ~]+$//;
@@ -5340,7 +5329,7 @@ sub rec_stream_folder {
     ParseRecordings($parent);
     my @recordings = @RECORDINGS;
 
-    # sort by date
+    # Sort by date
     @recordings = sort({ $b->{isfolder} <=> $a->{isfolder} ||
                          ciCmp($b->{isfolder} ? $a->{name} : "", $a->{isfolder} ? $b->{name} : "") ||
                          $a->{sse} <=> $b->{sse} } @recordings);
@@ -5357,7 +5346,7 @@ sub rec_stream_folder {
         if (!$recording->{isfolder}  &&
              $recording->{parent} eq $parent) {
 
-            # inplace playlist
+            # Inplace playlist
             my ($id) = $recording->{recording_id};
             my ($i, $title, $newtitle);
             my ($date, $time);
@@ -5479,7 +5468,7 @@ sub getReferer {
 }
 
 #############################################################################
-# live streaming
+# Live streaming
 #############################################################################
 sub streamdevURI {
     my $url;
@@ -5526,7 +5515,7 @@ sub live_stream {
 }
 
 #############################################################################
-# automatic timers
+# Automatic timers
 #############################################################################
 sub at_timer_list {
     return if (UptoDate() != 0);
@@ -5643,7 +5632,6 @@ sub at_timer_edit {
 
     my @at = AT_Read();
 
-    #
     my @chans;
     for my $chan (@{$CHAN{$CONFIG{CHANNELS_WANTED_AUTOTIMER}}->{channels}}) {
         if ($chan->{vdr_id}) {
@@ -5854,7 +5842,7 @@ sub at_timer_test {
         url      => $MyURL,
         channels => \@chans,
 
-        #TODO    $q->Vars,
+        # TODO    $q->Vars,
         active      => $q->param("active"),
         pattern     => $pattern,
         title       => $q->param("title") ? $q->param("title") : 0,
@@ -5918,7 +5906,7 @@ sub getStartTime {
 }
 
 #############################################################################
-# timeline
+# Timeline
 #############################################################################
 sub prog_timeline {
     return if (UptoDate() != 0);
@@ -5926,7 +5914,7 @@ sub prog_timeline {
     my $myself = Encode_Referer($MyURL . "?" . $Query);
     $CONFIG{CHANNELS_WANTED_TIMELINE} = $q->param("wanted_channels") if (defined $q->param("wanted_channels"));
 
-    # zeitpunkt bestimmen
+    # Determine time point
     my $border;
     if ($q->param("time")) {
         if ($q->param("frame")) {
@@ -5939,12 +5927,12 @@ sub prog_timeline {
     my $event_time = getStartTime(scalar $q->param("time"), undef, $border);
     my $event_time_to;
 
-    # calculate start time of the 30 min interval to avoid gaps at the beginning
+    # Calculate start time of the 30 min interval to avoid gaps at the beginning
     my $start_time = $event_time - $event_time % 1800;
 
     $event_time_to = $start_time + ($CONFIG{ZEITRAHMEN} * 3600);
 
-    # Timer parsen, und erstmal alle rausschmeissen die nicht in der Zeitzone liegen
+    # Parse timers and remove those that don't fall into the time zone
     my $TIM;
     for my $timer (ParseTimer(0)) {
         next if ($timer->{stopsse} <= $start_time or $timer->{startsse} >= $event_time_to);
@@ -5957,7 +5945,7 @@ sub prog_timeline {
 
     foreach (@{$CHAN{$CONFIG{CHANNELS_WANTED_TIMELINE}}->{channels}}) {
         if (ChannelHasEPG($_->{vdr_id})) {
-            foreach my $event (sort { $a->[EV_START] <=> $b->[EV_START] } @{ $EPG{$_->{vdr_id}} }) {    # Events durchgehen
+            foreach my $event (sort { $a->[EV_START] <=> $b->[EV_START] } @{ $EPG{$_->{vdr_id}} }) {  # Go thru the events
                 next if ($event->[EV_STOP] <= $start_time or $event->[EV_START] >= $event_time_to);
 
                 my $progname = $event->[EV_CHANNEL_NAME];
@@ -5975,7 +5963,7 @@ sub prog_timeline {
 #                        infurl => ($event->[EV_SUMMARY] ? sprintf("%s?aktion=prog_detail&amp;epg_id=%s&amp;vdr_id=%s&amp;referer=%s", $MyURL, $event->[EV_EVENT_ID], $event->[EV_VDR_ID], $myself) : undef),
 #                        recurl => sprintf("%s?aktion=timer_new_form&amp;epg_id=%s&amp;vdr_id=%s&amp;referer=%s", $MyURL, $event->[EV_EVENT_ID], $event->[EV_VDR_ID], $myself),
                         anchor => $event->[EV_EVENT_ID],
-                        timer => (defined $TIM->{ $event->[EV_TITLE] } && $TIM->{ $event->[EV_TITLE] }->{vdr_id} == $event->[EV_VDR_ID] && $TIM->{ $event->[EV_TITLE] }->{active} ? 1 : 0), #TODO
+                        timer => (defined $TIM->{ $event->[EV_TITLE] } && $TIM->{ $event->[EV_TITLE] }->{vdr_id} == $event->[EV_VDR_ID] && $TIM->{ $event->[EV_TITLE] }->{active} ? 1 : 0),  # TODO
                      }
                 );
             }
@@ -5993,7 +5981,7 @@ sub prog_timeline {
             );
         }
 
-        # needed for vdr 1.0.x, dunno why
+        # Needed for vdr 1.0.x, dunno why
 #        @show = sort({ $a->{vdr_id} <=> $b->{vdr_id} } @show);
         push(@{ $shows->{ $_->{vdr_id} } }, @show) if @show;
         undef @show;
@@ -6012,7 +6000,7 @@ sub prog_timeline {
 }
 
 #############################################################################
-# summary
+# Summary
 #############################################################################
 sub prog_summary {
     return if (UptoDate() != 0);
@@ -6026,7 +6014,7 @@ sub prog_summary {
 
     my @timers = ParseTimer(0);
 
-    # zeitpunkt bestimmen
+    # Determine time point
     my $event_time = getStartTime($time);
 
     my $pattern;
@@ -6053,7 +6041,7 @@ sub prog_summary {
             for my $word (split(/ +/, $pattern)) {
                 if ($word) {
                     if ($can_use_encode) {
-                        # case-insensitive search for 'abc' from fastest to slowest:
+                        # Case-insensitive search for 'abc' from fastest to slowest:
                         # (?>a|A)(?>b|B)(?>c|C) on byte strings
                         # [aA][bB][cC] on unicode strings
                         # substr() + uc()/lc() on unicode strings
@@ -6063,7 +6051,7 @@ sub prog_summary {
                         for my $ch (split(//, $word)) {
                             if (uc($ch) ne lc($ch)) {
                                 if (!@pat && !defined($prefix)) {
-                                    # first character
+                                    # First character
                                     $prefix = $ch;
                                 } else {
                                     push(@pat, "(?>");
@@ -6200,7 +6188,7 @@ sub prog_summary {
                 );
                 last if (!$search);
             }
-        } elsif (!$search && $CONFIG{CHANNELS_WITHOUT_EPG}) { # no EPG
+        } elsif (!$search && $CONFIG{CHANNELS_WITHOUT_EPG}) {  # No EPG
             push(@show,
                 {  date        => my_strftime("%x",     $event_time),
                    longdate    => my_strftime("%A, %x", $event_time),
@@ -6220,10 +6208,10 @@ sub prog_summary {
     }
 
     if ($search) {
-        # sort by event's start time and with equal start time sort by channel id
+        # Sort by event's start time and with equal start time sort by channel id
         @show = sort({ $a->{event_start} <=> $b->{event_start} || $a->{vdr_id} <=> $b->{vdr_id} } @show);
     } else {
-        # sort by channel id
+        # Sort by channel id
         @show = sort({ $a->{vdr_id} <=> $b->{vdr_id} } @show);
     }
 
@@ -6254,7 +6242,6 @@ sub prog_summary {
         }
     }
 
-    #
     my $label = $next ? gettext("What's on after") : gettext("What's on at");
     my $vars = { rows    => \@show,
                  now     => $displayed_time,
@@ -6271,7 +6258,7 @@ sub prog_summary {
 }
 
 #############################################################################
-# recordings
+# Recordings
 #############################################################################
 sub rec_list {
     my @recordings;
@@ -6287,9 +6274,9 @@ sub rec_list {
         $parent = uri_escape($parent);
     }
 
-    ParseRecordings($parent); # returns by parent filtered list
+    ParseRecordings($parent);  # Returns by parent filtered list
 
-    # create path array
+    # Create path array
     my @path;
     my @split_parent = split("~", $parent);
 
@@ -6395,7 +6382,7 @@ sub ParseRecordings {
     my $parent_select = shift;
     Log(LOG_DEBUG, "[ParseRecordings] start parent: $parent_select");
 
-    # clear global lists
+    # Clear global lists
     @RECORDINGS = ();
     %RECORDING_FOLDERS = {};
     %RECORDING_BY_ID =  {};
@@ -6440,7 +6427,7 @@ sub ParseRecordings {
             $lengthmin = $length;
         }
 
-        # store recording in hash
+        # Store recording in hash
         $RECORDING_BY_ID{$id}->{'name'}      = $rec_name;
         $RECORDING_BY_ID{$id}->{'date'}      = $date;
         $RECORDING_BY_ID{$id}->{'time'}      = $time;
@@ -6450,7 +6437,7 @@ sub ParseRecordings {
         $RECORDING_BY_ID{$id}->{'new'}       = $new;
         $RECORDING_BY_ID{$id}->{'lengthmin'} = $lengthmin;
 
-        # create folder tree
+        # Create folder tree
         my $parent;
         if (@path) {
             while (scalar(@path) > 0) {
@@ -6475,7 +6462,7 @@ sub ParseRecordings {
         $folder_entries = $RECORDING_FOLDERS{$parent_select};
     };
 
-    ## Folders
+    # Folders
     if (scalar(keys %$folder_entries) > 0) {
         foreach my $name (sort keys %$folder_entries) {
             my $folder = $folder_entries->{$name};
@@ -6504,7 +6491,7 @@ sub ParseRecordings {
 
         $parent    = $RECORDING_BY_ID{$id}->{'parent'};
 
-        next if ($parent_select ne $parent); # skip adding entries to list which are not selected
+        next if ($parent_select ne $parent);  # Skip adding entries to list which are not selected
 
         $name      = $RECORDING_BY_ID{$id}->{'name'};
         $date      = $RECORDING_BY_ID{$id}->{'date'};
@@ -6519,10 +6506,10 @@ sub ParseRecordings {
         my $yearofrecording;
         if ($FEATURES{VDRVERSION} >= 10326) {
 
-            # let localtime() decide about the century
+            # Let localtime() decide about the century
             $yearofrecording = substr($date, 6, 2);
 
-            # alternatively decide about the century ourself
+            # Alternatively decide about the century ourself
             #    my $shortyear = substr($date,6,2);
             #    if ($shortyear > 70) {
             #        $yearofrecording = "19" . $shortyear;
@@ -6531,14 +6518,14 @@ sub ParseRecordings {
             #    }
         } else {
 
-            # old way of vdradmin to handle the date while vdr did not report the year
+            # Old way of vdradmin to handle the date while vdr did not report the year
             # current year was assumed.
             if ($date eq "29.02") {
                 $yearofrecording = "2004";
             } else {
                 $yearofrecording = my_strftime("%Y");
             }
-        }    # endif
+        }  # endif
 
         my $name_js = $name;
         $name_js =~ s/\'/\\\'/g;
@@ -6560,8 +6547,8 @@ sub ParseRecordings {
                 delurl        => $MyURL . "?aktion=rec_delete&amp;rec_delete=y&amp;id=$id",
                 editurl       => $FEATURES{REC_RENAME} ? $MyURL . "?aktion=rec_edit&amp;id=$id" : undef,
                 infurl        => $MyURL . "?aktion=rec_detail&amp;id=$id",
-                playurl       => $FEATURES{VDRVERSION} >= 10331 ? $MyURL . "?aktion=rec_play&amp;id=$id" : undef, #TODO
-                cuturl        => $FEATURES{VDRVERSION} >= 10331 ? $MyURL . "?aktion=rec_cut&amp;id=$id" : undef, #TODO
+                playurl       => $FEATURES{VDRVERSION} >= 10331 ? $MyURL . "?aktion=rec_play&amp;id=$id" : undef,  # TODO
+                cuturl        => $FEATURES{VDRVERSION} >= 10331 ? $MyURL . "?aktion=rec_cut&amp;id=$id" : undef,  # TODO
                 streamurl     => ($CONFIG{ST_FUNC} && $CONFIG{ST_REC_ON}) ? $MyStreamBase . $CONFIG{REC_EXT} . "?aktion=rec_stream&amp;id=$id" : undef
              }
         );
@@ -6741,7 +6728,7 @@ sub rec_delete {
                 }
             }
             # VDR 2.3.x workaround:
-            # delete starting with the largest id and proceed to the smallest.
+            # Delete starting with the largest id and proceed to the smallest.
             # In this case, ids won't change while removing items from the list.
             @id_arr = sort {$b <=> $a} @id_arr;
             for my $del_id (@id_arr) {
@@ -6786,7 +6773,7 @@ sub recRunCmd {
         last if ($rec_id == $id);
     }
 
-    $time = substr($time, 0, 5);    # needed for wareagel-patch
+    $time = substr($time, 0, 5);  # Needed for wareagel-patch
     if ($rec_id == $id) {
         chomp($title);
         ($day,  $month)  = split(/\./, $date);
@@ -6823,7 +6810,7 @@ sub findVideoFolder {
 
 sub rec_edit {
 
-    # determine referer (redirect to where we come from)
+    # Determine referer (Redirect to where we come from)
     my $ref = getReferer();
 
     my $vars = getRecInfo(scalar $q->param("id"), $ref ? Encode_Referer($ref) : undef, "renr");
@@ -6863,7 +6850,7 @@ sub rec_cut {
 }
 
 #############################################################################
-# configuration
+# Configuration
 #############################################################################
 sub config {
     my $error_msg;
@@ -6929,10 +6916,9 @@ sub config {
         ApplyConfig();
     }
 
-    # vdradmind.conf writable?
+    # Is vdradmind.conf writable?
     $error_msg .= sprintf(gettext("Configuration file %s not writable! Configuration won't be saved!") . "<br />", $CONFFILE) unless (-w $CONFFILE);
 
-    #
     my @LOGINPAGES_DESCRIPTION = (gettext("What's On Now?"), gettext("Playing Today?"), gettext("Timeline"), gettext("Channels"), gettext("Timers"), gettext("Recordings"));
     my (@loginpages);
     my $i = 0;
@@ -6946,7 +6932,6 @@ sub config {
         $i++;
     }
 
-    #
     my @template;
     for my $dir (<$TEMPLATEDIR/*>) {
         next if (!-d $dir);
@@ -7029,7 +7014,7 @@ sub config {
 }
 
 #############################################################################
-# remote control
+# Remote control
 #############################################################################
 sub rc_show {
     $CONFIG{CHANNELS_WANTED_WATCHTV} = $q->param("wanted_channels") if (defined $q->param("wanted_channels"));
@@ -7065,7 +7050,7 @@ sub rc_hitk {
     }
     SendCMD("hitk $key");
 
-    #XXX
+    # XXX
     SendFile("bilder/spacer.gif");
 }
 
@@ -7120,7 +7105,7 @@ sub show_help {
 }
 
 #############################################################################
-# information
+# Information
 #############################################################################
 sub about {
     my $vars = {
@@ -7129,7 +7114,7 @@ sub about {
 }
 
 #############################################################################
-# experimental
+# Experimental
 #############################################################################
 sub grab_picture {
     $CONFIG{TV_INTERVAL} = $q->param("interval") if($q->param("interval"));
@@ -7155,7 +7140,7 @@ sub grab_picture {
         # Grab using temporary file
         my $file = new File::Temp(TEMPLATE => "vdr-XXXXX", DIR => File::Spec->tmpdir(), UNLINK => 1, SUFFIX => ".jpg");
         chmod 0666, $file if (-e $file);
-        SendCMD("grab $file jpeg 70 $width $height");
+        SendCMD("grab $file jpeg 80 $width $height");
         if (-e $file && -r _) {
             return (header("200", "image/jpeg", ReadFile($file)));
         } else {
@@ -7170,7 +7155,7 @@ sub grab_picture {
         }
     } else {
         my $image;
-        for (SendCMD("grab .jpg 70 $width $height")) {
+        for (SendCMD("grab .jpg 80 $width $height")) { # TODO: Adjustable image quality
             $image .= $_ unless (/Grabbed image/);
         }
         return SendFile("bilder/noise.gif") if ($image =~ /Grab image failed/);
@@ -7280,7 +7265,7 @@ sub export_channels_m3u {
 # Authentication
 #############################################################################
 
-sub subnetcheck { #TODO: IPv6 support
+sub subnetcheck { # TODO: IPv6 support
     my $ip   = $_[0];
     my $nets = $_[1];
     my ($ip1, $ip2, $ip3, $ip4, $net_base, $net_range, $net_base1, $net_base2, $net_base3, $net_base4, $bin_ip, $bin_net);
@@ -7306,7 +7291,7 @@ sub subnetcheck { #TODO: IPv6 support
 }
 
 #############################################################################
-# communication with vdr
+# Communication with vdr
 #############################################################################
 package SVDRP;
 


### PR DESCRIPTION
Changes:
- Added a new CSS class `.col_pattern` to style the pattern column in the timer list.
- Refactored HTML structure in `timer_list.html` for better readability and maintainability, including consistent indentation and spacing.
- Enhanced the timer list display by adding a new column for search patterns.
- Updated the Perl script `vdradmind.pl` to version 3.6.14, introducing support for the TVScraper plugin.
- Improved metadata extraction in the `extract_timer_metadata` function to handle new TVScraper fields.
- Cleaned up comments and ensured consistent formatting throughout the code.

Sample screenshot:
<img width="1663" height="567" alt="Auswahl_448" src="https://github.com/user-attachments/assets/d57643b7-0d3b-4f70-9b4a-922f4b78909e" />

**It seems there is a coding issue:** The pull request is malforming umlauts (äöü...). No idea what causes this. IDE shows files are all in UTF-8

Please review.